### PR TITLE
feat: add path for error message

### DIFF
--- a/packages/common/src/standard-validate.ts
+++ b/packages/common/src/standard-validate.ts
@@ -1,7 +1,9 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 
-export function createIssueMsg(issues: readonly { message: string }[]) {
-	const stdIssues = issues.map((issue) => issue.message);
+export function createIssueMsg(issues: readonly StandardSchemaV1.Issue[]) {
+	const stdIssues = issues.map(
+		(issue) => `${issue.message}${issue.path ? ` at ${issue.path}` : ""}`,
+	);
 	return stdIssues.length > 0 ? stdIssues[0] : "";
 }
 
@@ -15,7 +17,7 @@ export function standardValidate<T extends StandardSchemaV1>(
 	}
 	if (parsed.issues) {
 		const reducedIssues = createIssueMsg(parsed.issues);
-		throw new Error(`❌ Invalid environment variables: ${JSON.stringify(reducedIssues, null, 2)}`);
+		throw new Error(`❌ Invalid: ${JSON.stringify(reducedIssues, null, 2)}`);
 	}
 	return parsed.value;
 }

--- a/packages/common/src/standard-validate.ts
+++ b/packages/common/src/standard-validate.ts
@@ -16,8 +16,7 @@ export function standardValidate<T extends StandardSchemaV1>(
 		throw new TypeError("Schema validation must be synchronous");
 	}
 	if (parsed.issues) {
-		const reducedIssues = createIssueMsg(parsed.issues);
-		throw new Error(`❌ Invalid: ${JSON.stringify(reducedIssues, null, 2)}`);
+		throw new Error(`❌ Invalid: ${JSON.stringify(parsed.issues, null, 2)}`);
 	}
 	return parsed.value;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Validation messages now include the affected path when available, shown as “message at path” for clearer issue location.
  - The first validation issue is still shown; empty states remain blank.

- Bug Fixes
  - Error reporting wording simplified to “❌ Invalid: …” and now includes the structured issue details for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->