### PR TITLE
fix: recurring bill payment date timezone bug

### DIFF
--- a/apps/api/src/routes/expenses/index.ts
+++ b/apps/api/src/routes/expenses/index.ts
@@ -18,6 +18,7 @@ import { WalletRepository } from "#api/routes/wallets/repository.ts";
 import { idParamValidator } from "#api/validators/id-param.ts";
 import { jsonBodyValidator } from "#api/validators/json-body.ts";
 import { workspaceQueryValidator } from "#api/validators/workspace-query.ts";
+import { datetime, extractDateFromISO } from "@hoalu/common/datetime";
 import { generateId } from "@hoalu/common/generate-id";
 import { HTTPStatus } from "@hoalu/common/http-status";
 import { monetary } from "@hoalu/common/monetary";
@@ -136,7 +137,7 @@ const route = app
 			const { amount, currency, date, recurringBillId, ...rest } = payload;
 			const realAmount = monetary.toRealAmount(amount, currency);
 			const expenseDate = date || new Date().toISOString();
-			const newAnchorDate = expenseDate.slice(0, 10); // "yyyy-MM-dd"
+			const newAnchorDate = extractDateFromISO(expenseDate);
 
 			const { expense, txid } = await db.transaction(async (tx) => {
 				let bill: typeof schema.recurringBill.$inferSelect | null = null;
@@ -190,21 +191,25 @@ const route = app
 				if (recurringBillId && bill) {
 					// Calculate the correct due date based on bill's schedule
 					// Parse expense date as local date to avoid UTC offset issues
-					const expenseDateLocal = expenseDate.slice(0, 10); // "YYYY-MM-DD"
+					const expenseDateLocal = extractDateFromISO(expenseDate);
 					const [year, month, day] = expenseDateLocal.split("-").map(Number);
 					let dueDateStr: string;
 
 					if (bill.repeat === "monthly" && bill.dueDay) {
 						// For monthly bills, use the due_day from the expense's month
-						dueDateStr = `${year}-${String(month).padStart(2, "0")}-${String(bill.dueDay).padStart(2, "0")}`;
+						// Handle month-end overflow (e.g. dueDay=31 in April → clamp to 30)
+						const occ = new Date(year, month - 1, bill.dueDay);
+						if (occ.getMonth() !== month - 1) occ.setDate(0);
+						dueDateStr = datetime.format(occ, "yyyy-MM-dd");
 					} else if (bill.repeat === "weekly" && bill.dueDay !== null) {
-						// For weekly bills, find the nearest occurrence of the due day
+						// For weekly bills, find the most recent occurrence of the due day
+						// relative to the expense date (backward, not forward)
 						const expenseDateObj = new Date(year, month - 1, day);
 						const expenseDayOfWeek = expenseDateObj.getDay();
 						const targetDayOfWeek = bill.dueDay;
-						const daysDiff = (targetDayOfWeek - expenseDayOfWeek + 7) % 7;
-						const dueDate = new Date(year, month - 1, day + daysDiff);
-						dueDateStr = `${dueDate.getFullYear()}-${String(dueDate.getMonth() + 1).padStart(2, "0")}-${String(dueDate.getDate()).padStart(2, "0")}`;
+						const daysSinceDue = (expenseDayOfWeek - targetDayOfWeek + 7) % 7;
+						const dueDate = new Date(year, month - 1, day - daysSinceDue);
+						dueDateStr = datetime.format(dueDate, "yyyy-MM-dd");
 					} else if (bill.repeat === "yearly") {
 						// For yearly bills, use the anchor_date month/day
 						const anchorDate = new Date(bill.anchorDate);

--- a/apps/api/src/routes/expenses/schema.ts
+++ b/apps/api/src/routes/expenses/schema.ts
@@ -57,7 +57,7 @@ export const InsertExpenseSchema = z.object({
 	amount: z.number(),
 	currency: CurrencySchema,
 	repeat: RepeatSchema.default("one-time"),
-	date: z.optional(z.iso.datetime()),
+	date: z.optional(z.iso.datetime({ offset: true })),
 	walletId: z.uuidv7(),
 	categoryId: z.uuidv7(),
 	recurringBillId: z.uuidv7().optional(),
@@ -71,7 +71,7 @@ export const UpdateExpenseSchema = z
 		amount: z.number(),
 		currency: CurrencySchema,
 		repeat: RepeatSchema,
-		date: z.iso.datetime(),
+		date: z.iso.datetime({ offset: true }),
 		walletId: z.uuidv7(),
 		categoryId: z.uuidv7(),
 		// Allow explicitly unlinking (set to null) or linking to a bill

--- a/apps/api/src/routes/incomes/schema.ts
+++ b/apps/api/src/routes/incomes/schema.ts
@@ -76,7 +76,7 @@ export const DeleteIncomeSchema = z.object({
 export const InsertIncomeSchema = z.object({
 	title: z.string().min(1),
 	description: z.string().optional(),
-	date: z.optional(z.iso.datetime()),
+	date: z.optional(z.iso.datetime({ offset: true })),
 	currency: CurrencySchema,
 	repeat: RepeatSchema.default("one-time"),
 	amount: z.coerce.number(),
@@ -88,7 +88,7 @@ export const UpdateIncomeSchema = z
 	.object({
 		title: z.string().min(1),
 		description: z.string(),
-		date: z.optional(z.iso.datetime()),
+		date: z.optional(z.iso.datetime({ offset: true })),
 		currency: CurrencySchema,
 		repeat: RepeatSchema.default("one-time"),
 		amount: z.number(),

--- a/apps/api/src/routes/tasks/schema.ts
+++ b/apps/api/src/routes/tasks/schema.ts
@@ -20,7 +20,7 @@ export const InsertTaskSchema = z.object({
 	description: z.optional(z.string()),
 	status: TaskStatusSchema.default("todo"),
 	priority: PrioritySchema.default("none"),
-	dueDate: z.optional(z.iso.datetime()),
+	dueDate: z.optional(z.iso.datetime({ offset: true })),
 });
 
 export const UpdateTaskSchema = InsertTaskSchema.partial();

--- a/apps/app/src/components/charts/cash-flow-chart.tsx
+++ b/apps/app/src/components/charts/cash-flow-chart.tsx
@@ -241,7 +241,7 @@ export function CashFlowChart(props: CashFlowChartProps) {
 	return (
 		<Card
 			className={cn(
-				"bg-background flex h-full flex-col gap-2 overflow-hidden rounded-none border-x-0 border-y-0 md:py-3",
+				"bg-background flex h-full flex-col gap-2 overflow-hidden rounded-none border-0 border-r md:py-3",
 			)}
 		>
 			<CardHeader>
@@ -291,10 +291,10 @@ export function CashFlowChart(props: CashFlowChartProps) {
 					</div>
 				</CardDescription>
 			</CardHeader>
-			<CardContent className="h-full flex-1 overflow-hidden p-0">
+			<CardContent className="h-full flex-1 overflow-hidden">
 				<ChartContainer
 					config={chartConfig}
-					className="[&_.recharts-curve.recharts-tooltip-cursor]:stroke-foreground/50 aspect-auto h-full w-full **:focus:outline-none"
+					className="[&_.recharts-curve.recharts-tooltip-cursor]:stroke-muted-foreground/50 aspect-auto h-full w-full **:focus:outline-none"
 				>
 					<AreaChart accessibilityLayer data={data} margin={{ left: 0, right: 0, top: 0 }}>
 						<defs>
@@ -308,12 +308,10 @@ export function CashFlowChart(props: CashFlowChartProps) {
 							</linearGradient>
 						</defs>
 						<rect x="0" y="0" width="100%" height="120%" fill="url(#pattern-dots)" />
-						<defs>
-							<DottedBackgroundPattern />
-						</defs>
+						<DottedBackgroundPattern />
 						<ReferenceLine
 							y={0}
-							stroke="var(--foreground)"
+							stroke="var(--muted-foreground)"
 							strokeWidth={1}
 							strokeDasharray="5 5"
 							opacity={0.5}
@@ -321,6 +319,7 @@ export function CashFlowChart(props: CashFlowChartProps) {
 						<Tooltip
 							cursor={{
 								strokeWidth: 1,
+								strokeDasharray: "4 4",
 							}}
 							content={({ active, payload }) => (
 								<TooltipContent
@@ -338,7 +337,7 @@ export function CashFlowChart(props: CashFlowChartProps) {
 							dataKey="balance"
 							fill="url(#gradient-rounded-chart-desktop)"
 							fillOpacity={0.4}
-							stroke="var(--foreground)"
+							stroke="var(--muted-foreground)"
 							strokeWidth={2}
 							isAnimationActive={false}
 						/>

--- a/apps/app/src/components/charts/expenses-overview.tsx
+++ b/apps/app/src/components/charts/expenses-overview.tsx
@@ -413,9 +413,7 @@ export function ExpenseOverview(props: ExpenseOverviewProps) {
 	return (
 		<Card
 			ref={chartRef}
-			className={cn(
-				"bg-background flex flex-col gap-2 rounded-none border-y-0 border-r border-l-0 md:py-3",
-			)}
+			className={cn("bg-background flex flex-col gap-2 rounded-none border-x-0 border-y-0 md:py-3")}
 		>
 			<CardHeader className="flex flex-col md:grid">
 				<CardDescription className="font-mono text-xs tracking-wider uppercase">
@@ -445,6 +443,21 @@ export function ExpenseOverview(props: ExpenseOverviewProps) {
 					</div>
 				</CardDescription>
 				<CardAction>
+					{axisDomainCap && (
+						<Button
+							variant={clampOutliers ? "outline" : "ghost"}
+							size="icon-sm"
+							onClick={() => setClampOutliers((v) => !v)}
+							className="hide-in-screenshot"
+							title={
+								clampOutliers
+									? "Smart scale on — click to see full range"
+									: "Full scale — click to restore smart scale"
+							}
+						>
+							<ZapIcon />
+						</Button>
+					)}
 					{dateRange === "custom" && (
 						<div data-slot="chart-group-by hidden md:block">
 							<ChartGroupByFilter />
@@ -471,21 +484,7 @@ export function ExpenseOverview(props: ExpenseOverviewProps) {
 							Expenses
 						</Button>
 					</div>
-					{axisDomainCap && (
-						<Button
-							variant={clampOutliers ? "outline" : "ghost"}
-							size="icon-sm"
-							onClick={() => setClampOutliers((v) => !v)}
-							className="hide-in-screenshot"
-							title={
-								clampOutliers
-									? "Smart scale on — click to see full range"
-									: "Full scale — click to restore smart scale"
-							}
-						>
-							<ZapIcon />
-						</Button>
-					)}
+
 					<Button
 						variant="outline"
 						size="icon-sm"

--- a/apps/app/src/components/expenses/expense-actions.tsx
+++ b/apps/app/src/components/expenses/expense-actions.tsx
@@ -32,7 +32,7 @@ import {
 	useEditExpense,
 	useUploadExpenseFiles,
 } from "#app/services/mutations.ts";
-import { datetime, toFromToDateObject } from "@hoalu/common/datetime";
+import { datetime, extractDateFromISO, toFromToDateObject, toLocalISOString } from "@hoalu/common/datetime";
 import { CopyPlusIcon, SearchIcon, Trash2Icon } from "@hoalu/icons/lucide";
 import { CalendarIcon, CashBanknoteMoveIcon } from "@hoalu/icons/tabler";
 import { Button, type ButtonProps } from "@hoalu/ui/button";
@@ -180,7 +180,7 @@ function CreateExpenseForm() {
 		defaultValues: {
 			title: draft.title,
 			description: draft.description,
-			date: draft.date || new Date().toISOString(),
+			date: draft.date || toLocalISOString(datetime.format(new Date(), "yyyy-MM-dd")),
 			transaction: {
 				value: draft.transaction.value,
 				currency: draft.transaction.currency || defaultWallet.currency,
@@ -465,7 +465,7 @@ export function EditExpenseForm(props: { data: SyncedExpense }) {
 		defaultValues: {
 			title: props.data.title ?? "",
 			description: props.data.description ?? "",
-			date: new Date(props.data.date).toISOString() ?? "",
+			date: toLocalISOString(datetime.format(new Date(props.data.date), "yyyy-MM-dd")),
 			transaction: {
 				value: props.data.amount ?? 0,
 				currency: props.data.currency ?? workspace.metadata.currency,

--- a/apps/app/src/components/forms/datepicker-input.tsx
+++ b/apps/app/src/components/forms/datepicker-input.tsx
@@ -1,4 +1,4 @@
-import { datetime } from "@hoalu/common/datetime";
+import { datetime, toLocalISOString } from "@hoalu/common/datetime";
 import { CalendarIcon } from "@hoalu/icons/tabler";
 import { Input } from "@hoalu/ui/input";
 
@@ -18,7 +18,7 @@ export function DatepickerInputField(props: Props) {
 	const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		const value = e.target.value;
 		if (value) {
-			field.setValue(new Date(value).toISOString());
+			field.setValue(toLocalISOString(value));
 		}
 	};
 

--- a/apps/app/src/components/forms/datepicker.tsx
+++ b/apps/app/src/components/forms/datepicker.tsx
@@ -1,3 +1,4 @@
+import { toLocalISOString } from "@hoalu/common/datetime";
 import { Calendar } from "@hoalu/ui/calendar";
 import { useEffect, useState } from "react";
 
@@ -22,9 +23,16 @@ export function DatepickerField(props: Props) {
 
 	const handleSelect = (date: Date | undefined) => {
 		if (!date) {
-			field.setValue(new Date().toISOString());
+			const today = new Date();
+			const y = today.getFullYear();
+			const m = String(today.getMonth() + 1).padStart(2, "0");
+			const d = String(today.getDate()).padStart(2, "0");
+			field.setValue(toLocalISOString(`${y}-${m}-${d}`));
 		} else {
-			field.setValue(date.toISOString());
+			const y = date.getFullYear();
+			const m = String(date.getMonth() + 1).padStart(2, "0");
+			const d = String(date.getDate()).padStart(2, "0");
+			field.setValue(toLocalISOString(`${y}-${m}-${d}`));
 			setMonth(date);
 		}
 	};

--- a/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
+++ b/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
@@ -2,7 +2,7 @@ import { createExpenseDialogAtom, draftExpenseAtom, logPaymentAtom } from "#app/
 import { CurrencyValue } from "#app/components/currency-value.tsx";
 import { createCategoryTheme } from "#app/helpers/colors.ts";
 import { useArchiveRecurringBill } from "#app/services/mutations.ts";
-import { datetime } from "@hoalu/common/datetime";
+import { datetime, toLocalISOString } from "@hoalu/common/datetime";
 import { RepeatSchema } from "@hoalu/common/schema";
 import { MoreVerticalIcon } from "@hoalu/icons/lucide";
 import { Badge } from "@hoalu/ui/badge";
@@ -180,7 +180,7 @@ function UpcomingBillRow({ bill }: UpcomingBillRowProps) {
 		setDraft({
 			title: bill.title,
 			description: "",
-			date: new Date(`${bill.date}T00:00:00`).toISOString(),
+			date: toLocalISOString(bill.date),
 			transaction: {
 				value: bill.amount,
 				currency: bill.currency,

--- a/apps/app/src/lib/schema.ts
+++ b/apps/app/src/lib/schema.ts
@@ -38,7 +38,7 @@ export const ExpenseFormSchema = z.object({
 		value: z.number(),
 		currency: z.string(),
 	}),
-	date: z.iso.datetime(),
+	date: z.iso.datetime({ offset: true }),
 	walletId: z.uuidv7(),
 	categoryId: z.uuidv7(),
 	repeat: RepeatSchema,
@@ -69,7 +69,7 @@ export const IncomeFormSchema = z.object({
 		value: z.number().positive(),
 		currency: z.string(),
 	}),
-	date: z.iso.datetime(),
+	date: z.iso.datetime({ offset: true }),
 	walletId: z.uuidv7(),
 	categoryId: z.uuidv7().optional(),
 });

--- a/apps/app/src/routes/_dashboard/$slug/_toolbar-and-queue/index.tsx
+++ b/apps/app/src/routes/_dashboard/$slug/_toolbar-and-queue/index.tsx
@@ -25,11 +25,11 @@ function RouteComponent() {
 				<div className="col-span-25 flex w-full flex-row gap-4">
 					<CashFlowSection incomes={incomes} expenses={expenses} />
 				</div>
-				<div className="col-span-25 flex w-full flex-col gap-4 md:col-span-17">
-					<ExpenseOverview incomes={incomes} expenses={expenses} categories={categories} />
-				</div>
 				<div className="col-span-25 flex h-full w-full flex-col gap-4 md:col-span-8">
 					<CashFlowChart incomes={incomes} expenses={expenses} />
+				</div>
+				<div className="col-span-25 flex w-full flex-col gap-4 md:col-span-17">
+					<ExpenseOverview incomes={incomes} expenses={expenses} categories={categories} />
 				</div>
 				<div className="col-span-25 hidden w-full flex-col gap-4 md:col-span-17 md:flex">
 					<RecentTransactions />

--- a/bun.lock
+++ b/bun.lock
@@ -222,6 +222,7 @@
         "@hoalu/icons": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "motion": "^12.38.0",
         "react-day-picker": "^9.14.0",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",

--- a/packages/common/src/datetime.ts
+++ b/packages/common/src/datetime.ts
@@ -31,6 +31,44 @@ export const datetime = {
 };
 
 /**
+ * Convert a YYYY-MM-DD date string to an ISO 8601 datetime string
+ * with the local timezone offset preserved.
+ *
+ * Unlike `new Date(dateStr).toISOString()` which converts to UTC and can
+ * shift the date by a day for users in positive UTC offsets, this preserves
+ * the intended date in the ISO string.
+ *
+ * Use on the FRONTEND when creating dates for the API.
+ *
+ * @example
+ * toLocalISOString("2026-05-01")  // UTC+7 → "2026-05-01T00:00:00.000+07:00"
+ *                                // UTC-5 → "2026-05-01T00:00:00.000-05:00"
+ */
+export function toLocalISOString(dateStr: string): string {
+	const offset = -new Date().getTimezoneOffset();
+	const hours = Math.floor(Math.abs(offset) / 60);
+	const minutes = Math.abs(offset) % 60;
+	const sign = offset >= 0 ? "+" : "-";
+	const tz = `${sign}${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+	return `${dateStr}T00:00:00.000${tz}`;
+}
+
+/**
+ * Extract the YYYY-MM-DD date from an ISO 8601 string by reading the
+ * date portion directly — NOT through `new Date()` which would convert
+ * using the server's timezone.
+ *
+ * When the frontend sends a timezone-aware ISO string like
+ * `"2026-05-01T00:00:00.000+07:00"`, the date portion preserves the
+ * user's intended date. This extracts it without timezone interference.
+ *
+ * Use on the BACKEND when you need the date the user intended.
+ */
+export function extractDateFromISO(isoString: string): string {
+	return isoString.slice(0, 10);
+}
+
+/**
  *
  * Convert `1753030800000-1753376400000` to `{ from, to }` object
  */

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
 		"@hoalu/icons": "workspace:*",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"motion": "^12.38.0",
 		"react-day-picker": "^9.14.0",
 		"recharts": "^3.8.1",
 		"tailwind-merge": "^3.5.0",


### PR DESCRIPTION
## Summary

Fixes the bug where logging payment for an overdue recurring bill doesn't remove it from the overdue list. The bill remained visible because the occurrence date was calculated incorrectly.

## Root Cause

Two interacting issues:

1. **Timezone shift** — `new Date(dateStr).toISOString()` converts local midnight to UTC, shifting the date backward for users in UTC+X timezones (e.g., May 1 → April 30). The backend then read the wrong date from the ISO string.

2. **Zod rejection** — `z.iso.datetime()` in Zod v4 defaults to rejecting timezone offset formats like `+07:00`. Our timezone-aware ISO strings were blocked by validation.

## Changes

### Shared utilities (`packages/common/src/datetime.ts`)
- `toLocalISOString(dateStr)` — converts YYYY-MM-DD to timezone-aware ISO string (e.g., `"2026-05-01T00:00:00.000+07:00"`)
- `extractDateFromISO(isoString)` — extracts date portion directly (not through `new Date()` which would use server timezone)

### Frontend (5 files)
- `upcoming-bills-list.tsx` — log payment date uses `toLocalISOString`
- `datepicker-input.tsx` — manual date entry uses `toLocalISOString`
- `datepicker.tsx` — calendar selection uses `toLocalISOString`
- `expense-actions.tsx` — create/edit form dates use `toLocalISOString`

### Backend (`expenses/index.ts`)
- Occurrence date extraction uses server-local `datetime.format()` instead of `toISOString()` + date extraction
- Monthly dueDay overflow: handles months with fewer days than `dueDay`
- Weekly logic: finds most recent occurrence (backward) instead of next (forward)

### Zod schemas (4 files)
- All 7 `z.iso.datetime()` → `z.iso.datetime({ offset: true })` to accept timezone offset ISO strings