### PR TITLE
fix(api): patch @better-auth/kysely-adapter for kysely 0.29 compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -293,7 +293,8 @@
     },
   },
   "overrides": {
-    "@better-auth/core": "^1.6.9",
+    "@openrouter/sdk": "^0.12.79",
+    "@tanstack/ai-openrouter>@openrouter/sdk": "^0.12.79",
     "chalk": "5.6.2",
     "ora": "8.2.0",
   },
@@ -740,7 +741,7 @@
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@openrouter/sdk": ["@openrouter/sdk@0.12.14", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-G32CZ1IkmtsGfQF7/mzcvt7W0Lmd6HUHFGjDWv5knBvL6sJcMmX6i3VPSIpHQYSgEqRQSxFuDROP6iErTu7XcA=="],
+    "@openrouter/sdk": ["@openrouter/sdk@0.12.79", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-0ZpwtnuHh3/B1piW9kHCUIQy6PAsaK/vjFdZuHxmCdAenCyUNsLA2mFpmfHNWRNb+bOO3yBc4IALa264UyzmBA=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,16 @@
 		"vite": "^8.0.13"
 	},
 	"overrides": {
-		"@better-auth/core": "^1.6.9",
+		"@openrouter/sdk": "^0.12.79",
+		"@tanstack/ai-openrouter>@openrouter/sdk": "^0.12.79",
 		"chalk": "5.6.2",
 		"ora": "8.2.0"
 	},
 	"packageManager": "bun@1.3.9",
 	"trustedDependencies": [
 		"@swc/core"
-	]
+	],
+	"patchedDependencies": {
+		"@better-auth/kysely-adapter@1.6.14": "patches/@better-auth%2Fkysely-adapter@1.6.14.patch"
+	}
 }

--- a/patches/@better-auth%2Fkysely-adapter@1.6.14.patch
+++ b/patches/@better-auth%2Fkysely-adapter@1.6.14.patch
@@ -1,0 +1,33 @@
+diff --git a/dist/bun-sqlite-dialect-DzNwOpKv.mjs b/dist/bun-sqlite-dialect-DzNwOpKv.mjs
+index adfbfd3b7700e4aa10d5d63aef4d25c806c9cbb9..4b2294d79aadf47e7e3afdac307858aeb2e9058d 100644
+--- a/dist/bun-sqlite-dialect-DzNwOpKv.mjs
++++ b/dist/bun-sqlite-dialect-DzNwOpKv.mjs
+@@ -1,4 +1,5 @@
+-import { CompiledQuery, DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE, DefaultQueryCompiler, sql } from "kysely";
++import { CompiledQuery, DefaultQueryCompiler, sql } from "kysely";
++import { DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE } from "kysely/migration";
+ //#region src/bun-sqlite-dialect.ts
+ var BunSqliteAdapter = class {
+ 	get supportsCreateIfNotExists() {
+diff --git a/dist/d1-sqlite-dialect-C2B7YsIT.mjs b/dist/d1-sqlite-dialect-C2B7YsIT.mjs
+index 1545e428a73da3747b96b142d7a0f40eaaa41b0e..c9f01f5afbc8085017220d7972f78bace72f9f7b 100644
+--- a/dist/d1-sqlite-dialect-C2B7YsIT.mjs
++++ b/dist/d1-sqlite-dialect-C2B7YsIT.mjs
+@@ -1,4 +1,5 @@
+-import { DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE, SqliteAdapter, SqliteQueryCompiler } from "kysely";
++import { SqliteAdapter, SqliteQueryCompiler } from "kysely";
++import { DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE } from "kysely/migration";
+ //#region src/d1-sqlite-dialect.ts
+ var D1SqliteAdapter = class extends SqliteAdapter {};
+ var D1SqliteDriver = class {
+diff --git a/dist/node-sqlite-dialect.mjs b/dist/node-sqlite-dialect.mjs
+index 878100c374a231456d1965b1298bb7d8fa14df7c..794094ec5d0825252b8c071653b3d5772953be8a 100644
+--- a/dist/node-sqlite-dialect.mjs
++++ b/dist/node-sqlite-dialect.mjs
+@@ -1,4 +1,5 @@
+-import { CompiledQuery, DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE, DefaultQueryCompiler, sql } from "kysely";
++import { CompiledQuery, DefaultQueryCompiler, sql } from "kysely";
++import { DEFAULT_MIGRATION_LOCK_TABLE, DEFAULT_MIGRATION_TABLE } from "kysely/migration";
+ //#region src/node-sqlite-dialect.ts
+ var NodeSqliteAdapter = class {
+ 	get supportsCreateIfNotExists() {


### PR DESCRIPTION
## Summary

Fixes the `bun build` error in `apps/api` caused by `@better-auth/kysely-adapter@1.6.14` importing `DEFAULT_MIGRATION_TABLE` and `DEFAULT_MIGRATION_LOCK_TABLE` from the main `"kysely"` entry, which no longer exports them in `kysely >= 0.29`. They were moved to the `"kysely/migration"` subpath.

The upstream fix ([PR #9811](https://github.com/better-auth/better-auth/pull/9811)) is already merged but not yet released to npm.

## Changes

- **`patches/@better-auth%2Fkysely-adapter@1.6.14.patch`** — Bun patch that fixes the import paths in 3 dialect files (matching the upstream fix)
- **`package.json`** — Added `patchedDependencies` for Bun patch support, replaced stale `@better-auth/core` override with `@openrouter/sdk`
- **`bun.lock`** — Updated to reflect override changes

## Verification

- `bun run build` in `apps/api` passes cleanly
- `turbo prune @hoalu/api --docker` includes `patches/` automatically
- Bun auto-applies the patch on `bun install`