### PR TITLE
fix(docker): pin turbo@latest and pnpm@11 in base image

### DIFF
--- a/deployments/base.Dockerfile
+++ b/deployments/base.Dockerfile
@@ -4,6 +4,6 @@ RUN apk add --no-cache \
     python3 \
     make \
     gcc \
-    && npm install -g turbo pnpm
+    && npm install -g turbo@latest pnpm@11
 
 WORKDIR /repo


### PR DESCRIPTION
turbo 2.9.6 can't parse pnpm 11's patchedDependencies format in pnpm-lock.yaml, breaking `turbo prune --docker` during Docker builds.

Pinning `turbo@latest` ensures the Docker image always uses a compatible turbo version. pnpm is pinned to `@11` for stability.