### PR TITLE
fix(api): remove external node builtins from vite config

### DIFF
--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
 			fileName: () => "index.mjs",
 		},
 		rollupOptions: {
-			external: [/^node:/],
 			output: {
 				codeSplitting: false,
 			},


### PR DESCRIPTION
CJS libraries inside the bundled `index.mjs` call `require('node:stream')` which fails in ESM-only environments like Node.js with `type: module`.\n\nRemoving `external: [/^node:/]` from the Vite config lets Rolldown handle node builtins properly in the self-contained bundle.\n\nFixes Docker startup error:\n```\nError: Calling `require` for "node:stream" in an environment that doesn't expose the `require` function.\n```