### PR TITLE
fix: check tiptap commandManager null before accessing editor

### DIFF
--- a/apps/app/src/components/receipt/scan-queue-review-dialog.tsx
+++ b/apps/app/src/components/receipt/scan-queue-review-dialog.tsx
@@ -113,7 +113,7 @@ export function ScanQueueReviewDialogContent() {
 	});
 
 	const feedbackEditorState = useEditorState({
-		editor: feedbackEditor,
+		editor: feedbackEditor && !feedbackEditor.isDestroyed ? feedbackEditor : null,
 		selector: (ctx) => ({ isEmpty: ctx.editor?.isEmpty ?? true }),
 	});
 	const isFeedbackEmpty = feedbackEditorState?.isEmpty;
@@ -152,7 +152,9 @@ export function ScanQueueReviewDialogContent() {
 			setDate(jobData?.date ?? "");
 			setCategoryId(jobData?.suggestedCategoryId ?? "");
 			setError(null);
-			feedbackEditor?.commands.clearContent();
+			if (feedbackEditor && !feedbackEditor.isDestroyed) {
+				feedbackEditor.commands.clearContent();
+			}
 		}
 	}, [jobId, jobData, feedbackEditor, workspaceCurrency]);
 
@@ -173,7 +175,7 @@ export function ScanQueueReviewDialogContent() {
 	}, [hasPrev, completedJobs, currentIndex, setReviewDialog]);
 
 	const handleRefine = useCallback(() => {
-		if (!feedbackEditor || isFeedbackEmpty || !currentJob) return;
+		if (!feedbackEditor || feedbackEditor.isDestroyed || isFeedbackEmpty || !currentJob) return;
 		addJob({
 			...currentJob.input,
 			feedback: feedbackEditor.getText(),


### PR DESCRIPTION
TipTap v3's useEditor hook in React 19 can return a destroyed editor instance during component unmount/re-mount cycles. The object isn't null, so optional chaining (?.) doesn't protect you — but internally, editor.commandManager has been nulled out by destroy(). Accessing editor.commands then throws:

```
TypeError: Cannot read properties of null (reading 'commands')
```