### PR TITLE
fix: prevent tiptap crashes from destroyed editor instances

### DIFF
--- a/apps/app/src/components/forms/tiptap.tsx
+++ b/apps/app/src/components/forms/tiptap.tsx
@@ -28,7 +28,9 @@ export function TiptapField(props: Props) {
 	});
 
 	useEffect(() => {
-		editor?.commands.setContent(props.defaultValue || "");
+		if (editor && !editor.isDestroyed) {
+			editor.commands.setContent(props.defaultValue || "");
+		}
 	}, [editor, props.defaultValue]);
 
 	return (

--- a/apps/app/src/components/providers/dialog-provider.tsx
+++ b/apps/app/src/components/providers/dialog-provider.tsx
@@ -92,7 +92,7 @@ function Content(props: { id?: DialogId; data?: Record<string, any> }) {
 		case "scan-receipt":
 			return <ScanReceiptDialogContent />;
 		case "scan-queue-review":
-			return <ScanQueueReviewDialogContent />;
+			return <ScanQueueReviewDialogContent key={props.data?.jobId} />;
 		case "quick-expense":
 			return <QuickExpensesDialogContent />;
 

--- a/apps/app/src/components/tiptap.tsx
+++ b/apps/app/src/components/tiptap.tsx
@@ -15,7 +15,7 @@ export const extensions = [
 ];
 
 export function Toolbar({ editor }: { editor: Editor | null }) {
-	if (!editor) {
+	if (!editor || editor.isDestroyed) {
 		return null;
 	}
 


### PR DESCRIPTION
## Problem

React 19 concurrent rendering + Suspense creates race conditions with TipTap 3.25's new 
`useEditor` hook architecture (uses `useSyncExternalStore` + `scheduleDestroy(1ms)`).
When a dialog with a TipTap editor is deactivated by React (e.g. during Suspense boundary
switches or StrictMode double-mounts), the 1ms destroy timeout can fire while the component
is still holding a reference to the editor. Accessing `editor.commands` on a destroyed
editor throws:

```
TypeError: Cannot read properties of null (reading 'commands')
```

This appeared after upgrading React (19.2.6→19.2.7) and TipTap (3.23.5→3.25.0).

## Changes

### scan-queue-review-dialog.tsx (from #447)
- Guard `useEditorState` to pass `null` when editor is destroyed
- Guard `useEffect` clearContent call with `!editor.isDestroyed`
- Guard `handleRefine` callback with `editor.isDestroyed`

### This PR — additional hardening
- **forms/tiptap.tsx**: Guard `editor.commands.setContent` in useEffect
- **tiptap.tsx**: Guard `Toolbar` render — return null if `editor.isDestroyed`
- **dialog-provider.tsx**: Add `key={jobId}` to `ScanQueueReviewDialogContent`
  to force full unmount/remount when switching between receipt jobs, ensuring
  a fresh TipTap editor instance on every job change.

## Verification
- [x] Build passes (`pnpm --filter @hoalu/app run build`)
- [x] Dialog navigation (Next/Prev receipts) no longer crashes
- [x] Expense creation flow from receipt scan works end-to-end