### PR TITLE
refactor(app): migrate dialogs manager to Legend-State

### DIFF
--- a/apps/app/src/atoms/dialogs.ts
+++ b/apps/app/src/atoms/dialogs.ts
@@ -1,4 +1,4 @@
-import { atom, type PrimitiveAtom } from "jotai";
+import { observable } from "@legendapp/state";
 
 const DIALOG_ID = [
 	// workspace
@@ -38,105 +38,88 @@ const DIALOG_ID = [
 ] as const;
 export type DialogId = (typeof DIALOG_ID)[number];
 
-interface DialogData {
-	id: DialogId;
-	data: Record<string, any> | undefined;
-}
+type DialogData = { id: DialogId; data: Record<string, any> | undefined };
 
-interface DialogManagerAtom {
+interface DialogState {
 	currentId: DialogId | null;
-	dialogs: PrimitiveAtom<DialogData>[];
+	data: Record<string, any> | undefined;
+	open: boolean;
 }
 
-export const dialogStateAtom = atom(false);
-
-export const dialogManagerAtom = atom<DialogManagerAtom>({
+/**
+ * Single source of truth for the app's modal dialog. Only one dialog is open
+ * at a time, identified by `currentId`, with its optional `data` payload.
+ */
+export const dialog$ = observable<DialogState>({
 	currentId: null,
-	dialogs: [],
+	data: undefined,
+	open: false,
 });
 
-export const currentDialogAtom = atom(
-	(get) => {
-		const { currentId, dialogs } = get(dialogManagerAtom);
-		if (!currentId) {
-			return null;
-		}
-		const currentDialog = dialogs.find((dialog) => get(dialog).id === currentId);
-		return currentDialog ? get(currentDialog) : null;
-	},
-	(_get, set, id: DialogId | null) => {
-		set(dialogManagerAtom, (state) => ({
-			...state,
-			currentId: id,
-		}));
-	},
-);
-
-export const wipeOutDialogsAtom = atom(null, (_get, set) => {
-	set(dialogManagerAtom, {
-		currentId: null,
-		dialogs: [],
-	});
+/**
+ * The currently active dialog ({ id, data }) or null. Drives DialogProvider.
+ */
+export const currentDialog$ = observable<DialogData | null>(() => {
+	const currentId = dialog$.currentId.get();
+	return currentId ? { id: currentId, data: dialog$.data.get() } : null;
 });
 
-const dialogsAtom = atom((get) => get(dialogManagerAtom).dialogs);
+/**
+ * Close any open dialog and clear its state.
+ */
+export function wipeOutDialogs() {
+	dialog$.set({ currentId: null, data: undefined, open: false });
+}
 
 type Action = { state: true; data?: Record<string, any> | undefined } | { state: false };
 
-function createDialogAtom(id: DialogId) {
-	const basedAtom = atom(
-		(get) => {
-			const dialogs = get(dialogsAtom);
-			const dialogAtomById = dialogs.find((dialogAtom) => get(dialogAtom).id === id);
-			return dialogAtomById ? get(dialogAtomById) : null;
-		},
-		(get, set, action: Action) => {
-			set(dialogStateAtom, action.state);
-
-			if (!action.state) {
-				set(dialogManagerAtom, (state) => ({
-					currentId: state.currentId === id ? null : state.currentId,
-					dialogs: state.dialogs.filter((dialogAtom) => get(dialogAtom).id !== id),
-				}));
+/**
+ * Creates a controller for a single dialog id:
+ * - `$`  a computed observable resolving to { id, data } when this dialog is
+ *        active, otherwise null (read it in components with `useValue`).
+ * - `set` open/close this dialog, mirroring the previous atom write API
+ *        (`{ state: true, data }` / `{ state: false }`).
+ */
+function createDialog(id: DialogId) {
+	return {
+		$: observable<DialogData | null>(() =>
+			dialog$.currentId.get() === id ? { id, data: dialog$.data.get() } : null,
+		),
+		set: (action: Action) => {
+			if (action.state) {
+				dialog$.set({ currentId: id, data: action.data, open: true });
 			} else {
-				set(dialogManagerAtom, (state) => {
-					const filteredDialogs = state.dialogs.filter((atom) => get(atom).id !== id);
-					return {
-						currentId: id,
-						dialogs: [...filteredDialogs, atom({ id, data: action.data })],
-					};
-				});
+				dialog$.set({ currentId: null, data: undefined, open: false });
 			}
 		},
-	);
-	return basedAtom;
+	};
 }
 
-export const createWorkspaceDialogAtom = createDialogAtom("create-workspace");
-export const deleteWorkspaceDialogAtom = createDialogAtom("delete-workspace");
+export const createWorkspaceDialog = createDialog("create-workspace");
+export const deleteWorkspaceDialog = createDialog("delete-workspace");
 
-export const createExpenseDialogAtom = createDialogAtom("create-expense");
-export const deleteExpenseDialogAtom = createDialogAtom("delete-expense");
-export const scanReceiptDialogAtom = createDialogAtom("scan-receipt");
+export const createExpenseDialog = createDialog("create-expense");
+export const deleteExpenseDialog = createDialog("delete-expense");
+export const scanReceiptDialog = createDialog("scan-receipt");
 
-export const createWalletDialogAtom = createDialogAtom("create-wallet");
-export const editWalletDialogAtom = createDialogAtom("edit-wallet");
-export const deleteWalletDialogAtom = createDialogAtom("delete-wallet");
+export const createWalletDialog = createDialog("create-wallet");
+export const editWalletDialog = createDialog("edit-wallet");
+export const deleteWalletDialog = createDialog("delete-wallet");
 
-export const createCategoryDialogAtom = createDialogAtom("create-category");
-export const deleteCategoryDialogAtom = createDialogAtom("delete-category");
+export const createCategoryDialog = createDialog("create-category");
+export const deleteCategoryDialog = createDialog("delete-category");
 
-export const createRecurringBillDialogAtom = createDialogAtom("create-recurring-bill");
-export const archiveRecurringBillDialogAtom = createDialogAtom("archive-recurring-bill");
-export const unarchiveRecurringBillDialogAtom = createDialogAtom("unarchive-recurring-bill");
-export const deleteRecurringBillDialogAtom = createDialogAtom("delete-recurring-bill");
+export const createRecurringBillDialog = createDialog("create-recurring-bill");
+export const archiveRecurringBillDialog = createDialog("archive-recurring-bill");
+export const unarchiveRecurringBillDialog = createDialog("unarchive-recurring-bill");
+export const deleteRecurringBillDialog = createDialog("delete-recurring-bill");
 
-export const scanQueueReviewDialogAtom = createDialogAtom("scan-queue-review");
-export const quickExpenseDialogAtom = createDialogAtom("quick-expense");
+export const scanQueueReviewDialog = createDialog("scan-queue-review");
+export const quickExpenseDialog = createDialog("quick-expense");
 
-export const createIncomeDialogAtom = createDialogAtom("create-income");
-export const deleteIncomeDialogAtom = createDialogAtom("delete-income");
+export const createIncomeDialog = createDialog("create-income");
+export const deleteIncomeDialog = createDialog("delete-income");
 
-export const createEventDialogAtom = createDialogAtom("create-event");
-export const editEventDialogAtom = createDialogAtom("edit-event");
-export const deleteEventDialogAtom = createDialogAtom("delete-event");
+export const createEventDialog = createDialog("create-event");
+export const editEventDialog = createDialog("edit-event");
+export const deleteEventDialog = createDialog("delete-event");

--- a/apps/app/src/atoms/dialogs.ts
+++ b/apps/app/src/atoms/dialogs.ts
@@ -78,7 +78,9 @@ type Action = { state: true; data?: Record<string, any> | undefined } | { state:
  * - `$`  a computed observable resolving to { id, data } when this dialog is
  *        active, otherwise null (read it in components with `useValue`).
  * - `set` open/close this dialog, mirroring the previous atom write API
- *        (`{ state: true, data }` / `{ state: false }`).
+ *        (`{ state: true, data }` / `{ state: false }`). Closing is a no-op
+ *        when a different dialog is active, so open/close ordering between
+ *        two dialogs doesn't matter.
  */
 function createDialog(id: DialogId) {
 	return {
@@ -89,7 +91,10 @@ function createDialog(id: DialogId) {
 			if (action.state) {
 				dialog$.set({ currentId: id, data: action.data, open: true });
 			} else {
-				dialog$.set({ currentId: null, data: undefined, open: false });
+				const currentId = dialog$.currentId.peek();
+				if (currentId === id || currentId === null) {
+					wipeOutDialogs();
+				}
 			}
 		},
 	};

--- a/apps/app/src/components/categories/category-actions.tsx
+++ b/apps/app/src/components/categories/category-actions.tsx
@@ -12,13 +12,8 @@ import { Field, FieldGroup } from "@hoalu/ui/field";
 import { cn } from "@hoalu/ui/utils";
 import { useValue } from "@legendapp/state/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useSetAtom } from "jotai";
 
-import {
-	createCategoryDialogAtom,
-	deleteCategoryDialogAtom,
-	selectedCategory$,
-} from "#app/atoms/index.ts";
+import { createCategoryDialog, deleteCategoryDialog, selectedCategory$ } from "#app/atoms/index.ts";
 import { useAppForm } from "#app/components/forms/index.tsx";
 import { HotKey } from "#app/components/hotkey.tsx";
 import { createCategoryTheme } from "#app/helpers/colors.ts";
@@ -33,7 +28,7 @@ import { WarningMessage } from "../warning-message";
 import type { ColorSchema } from "@hoalu/schema/schema";
 
 export function CreateCategoryDialogTrigger() {
-	const setDialog = useSetAtom(createCategoryDialogAtom);
+	const setDialog = createCategoryDialog.set;
 
 	return (
 		<Button size="sm" onClick={() => setDialog({ state: true })}>
@@ -70,7 +65,7 @@ export function CreateCategoryForm({
 	type?: "expense" | "income";
 	callback?(): void;
 }) {
-	const setDialog = useSetAtom(createCategoryDialogAtom);
+	const setDialog = createCategoryDialog.set;
 	const mutation = useCreateCategory();
 	const form = useAppForm({
 		defaultValues: {
@@ -178,7 +173,7 @@ export function EditCategoryForm(props: { onEditCallback?(): void }) {
 		},
 	});
 
-	const setDialog = useSetAtom(deleteCategoryDialogAtom);
+	const setDialog = deleteCategoryDialog.set;
 
 	return (
 		<form.AppForm>
@@ -225,7 +220,7 @@ export function DeleteCategoryDialogContent() {
 	const mutation = useDeleteCategory();
 	const selectedCategory = useValue(selectedCategory$);
 	const setSelectedCategory = selectedCategory$.set;
-	const setDialog = useSetAtom(deleteCategoryDialogAtom);
+	const setDialog = deleteCategoryDialog.set;
 	const onDelete = async () => {
 		if (!selectedCategory.id) {
 			setDialog({ state: false });

--- a/apps/app/src/components/command-palette/command-palette.tsx
+++ b/apps/app/src/components/command-palette/command-palette.tsx
@@ -11,14 +11,9 @@ import {
 import { Kbd, KbdGroup } from "@hoalu/ui/kbd";
 import { Separator } from "@hoalu/ui/separator";
 import { useParams } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import {
-	createCategoryDialogAtom,
-	createExpenseDialogAtom,
-	createWalletDialogAtom,
-} from "#app/atoms/index.ts";
+import { createCategoryDialog, createExpenseDialog, createWalletDialog } from "#app/atoms/index.ts";
 import { useUpcomingBills } from "#app/components/upcoming-bills/use-upcoming-bills.ts";
 
 import { useExpenseSearch } from "./use-expense-search.ts";
@@ -35,9 +30,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 	const [search, setSearch] = useState("");
 	const { slug } = useParams({ from: "/_dashboard/$slug" });
 
-	const setCreateExpenseDialog = useSetAtom(createExpenseDialogAtom);
-	const setCreateWalletDialog = useSetAtom(createWalletDialogAtom);
-	const setCreateCategoryDialog = useSetAtom(createCategoryDialogAtom);
+	const setCreateExpenseDialog = createExpenseDialog.set;
+	const setCreateWalletDialog = createWalletDialog.set;
+	const setCreateCategoryDialog = createCategoryDialog.set;
 
 	const { filtered: filteredExpenses, recent: recentExpenses } = useExpenseSearch(
 		open ? slug : undefined,

--- a/apps/app/src/components/events/event-actions.tsx
+++ b/apps/app/src/components/events/event-actions.tsx
@@ -10,15 +10,11 @@ import {
 	DialogTitle,
 } from "@hoalu/ui/dialog";
 import { Field, FieldGroup } from "@hoalu/ui/field";
+import { useValue } from "@legendapp/state/react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useAtom, useSetAtom } from "jotai";
 import * as z from "zod";
 
-import {
-	createEventDialogAtom,
-	deleteEventDialogAtom,
-	editEventDialogAtom,
-} from "#app/atoms/dialogs.ts";
+import { createEventDialog, deleteEventDialog, editEventDialog } from "#app/atoms/dialogs.ts";
 import { type SyncedEvent, useLiveQueryEvents } from "#app/components/events/use-events.ts";
 import { DateRangeCalendarField } from "#app/components/forms/date-range-calendar.tsx";
 import { useAppForm } from "#app/components/forms/index.tsx";
@@ -47,7 +43,7 @@ const EVENT_STATUS_OPTIONS = [
 ];
 
 export function CreateEventDialogTrigger({ ...props }: ButtonProps) {
-	const setDialog = useSetAtom(createEventDialogAtom);
+	const setDialog = createEventDialog.set;
 	return (
 		<Button size="sm" {...props} onClick={() => setDialog({ state: true })}>
 			New event
@@ -71,7 +67,7 @@ export function CreateEventDialogContent() {
 function CreateEventForm() {
 	const workspace = useWorkspace();
 	const mutation = useCreateEvent();
-	const setDialog = useSetAtom(createEventDialogAtom);
+	const setDialog = createEventDialog.set;
 
 	const form = useAppForm({
 		defaultValues: {
@@ -148,7 +144,7 @@ function CreateEventForm() {
 }
 
 export function EditEventDialogContent() {
-	const [dialog] = useAtom(editEventDialogAtom);
+	const dialog = useValue(editEventDialog.$);
 	const events = useLiveQueryEvents();
 	const event = events.find((e) => e.id === dialog?.data?.id) ?? null;
 	if (!event) return null;
@@ -166,7 +162,7 @@ export function EditEventDialogContent() {
 function EditEventForm({ event }: { event: SyncedEvent }) {
 	const workspace = useWorkspace();
 	const mutation = useEditEvent();
-	const setDialog = useSetAtom(editEventDialogAtom);
+	const setDialog = editEventDialog.set;
 
 	const form = useAppForm({
 		defaultValues: {
@@ -257,7 +253,8 @@ export function DeleteEventDialogContent() {
 	const navigate = useNavigate();
 	const { slug } = useParams({ from: "/_dashboard/$slug" });
 	const mutation = useDeleteEvent();
-	const [dialog, setDialog] = useAtom(deleteEventDialogAtom);
+	const dialog = useValue(deleteEventDialog.$);
+	const setDialog = deleteEventDialog.set;
 
 	const onDelete = async () => {
 		if (!dialog?.data?.id) {

--- a/apps/app/src/components/events/event-details.tsx
+++ b/apps/app/src/components/events/event-details.tsx
@@ -13,9 +13,8 @@ import { Card, CardDescription, CardHeader, CardTitle } from "@hoalu/ui/card";
 import { Progress, ProgressIndicator, ProgressTrack } from "@hoalu/ui/progress";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hoalu/ui/tooltip";
 import { cn } from "@hoalu/ui/utils";
-import { useSetAtom } from "jotai";
 
-import { deleteEventDialogAtom, editEventDialogAtom } from "#app/atoms/dialogs.ts";
+import { deleteEventDialog, editEventDialog } from "#app/atoms/dialogs.ts";
 import { CurrencyValue } from "#app/components/currency-value.tsx";
 import { EventDateRange } from "#app/components/events/event-date-range.tsx";
 import {
@@ -48,8 +47,8 @@ export function EventDetailPanel({
 }: EventDetailPanelProps) {
 	const expenses = useLiveQueryEventExpenses(event.id);
 	const bills = useLiveQueryEventRecurringBills(event.id);
-	const setEditDialog = useSetAtom(editEventDialogAtom);
-	const setDeleteDialog = useSetAtom(deleteEventDialogAtom);
+	const setEditDialog = editEventDialog.set;
+	const setDeleteDialog = deleteEventDialog.set;
 	const {
 		metadata: { currency: workspaceCurrency },
 	} = useWorkspace();

--- a/apps/app/src/components/expenses/expense-actions.tsx
+++ b/apps/app/src/components/expenses/expense-actions.tsx
@@ -25,12 +25,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@hoalu/ui/tooltip";
 import { cn } from "@hoalu/ui/utils";
 import { useValue } from "@legendapp/state/react";
 import { getRouteApi, useNavigate, useParams } from "@tanstack/react-router";
-import { useAtom, useSetAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
 
 import {
-	createExpenseDialogAtom,
-	deleteExpenseDialogAtom,
+	createExpenseDialog,
+	deleteExpenseDialog,
 	draftExpense$,
 	logPayment$,
 	resetDraftExpense,
@@ -71,7 +71,7 @@ export function CreateExpenseDialogTrigger({
 	showKbd = true,
 	...props
 }: ButtonProps & { showKbd?: boolean }) {
-	const setDialog = useSetAtom(createExpenseDialogAtom);
+	const setDialog = createExpenseDialog.set;
 
 	return (
 		<Button size="sm" variant="default" {...props} onClick={() => setDialog({ state: true })}>
@@ -108,7 +108,7 @@ function CreateExpenseForm() {
 	const expenseFilesMutation = useUploadExpenseFiles();
 	const filesUploadRef = useRef<FilesCompactUploadRef>(null);
 
-	const setDialog = useSetAtom(createExpenseDialogAtom);
+	const setDialog = createExpenseDialog.set;
 	const draft = useValue(draftExpense$);
 	const setDraft = draftExpense$.set;
 	const logPayment = useValue(logPayment$);
@@ -349,7 +349,7 @@ function CreateExpenseForm() {
 }
 
 export function DeleteExpense({ id }: { id: string }) {
-	const setDialog = useSetAtom(deleteExpenseDialogAtom);
+	const setDialog = deleteExpenseDialog.set;
 
 	return (
 		<Tooltip>
@@ -374,7 +374,8 @@ export function DeleteExpenseDialogContent() {
 	const { slug } = useParams({ from: "/_dashboard/$slug" });
 	const navigate = useNavigate();
 	const mutation = useDeleteExpense();
-	const [dialog, setDialog] = useAtom(deleteExpenseDialogAtom);
+	const dialog = useValue(deleteExpenseDialog.$);
+	const setDialog = deleteExpenseDialog.set;
 
 	const onDelete = async () => {
 		if (!dialog?.data?.id) {

--- a/apps/app/src/components/incomes/income-actions.tsx
+++ b/apps/app/src/components/incomes/income-actions.tsx
@@ -15,12 +15,11 @@ import { useLocalStorage } from "@hoalu/ui/hooks";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hoalu/ui/tooltip";
 import { useValue } from "@legendapp/state/react";
 import { getRouteApi } from "@tanstack/react-router";
-import { useAtom, useSetAtom } from "jotai";
 import { useEffect } from "react";
 
 import {
-	createIncomeDialogAtom,
-	deleteIncomeDialogAtom,
+	createIncomeDialog,
+	deleteIncomeDialog,
 	draftIncome$,
 	resetDraftIncome,
 } from "#app/atoms/index.ts";
@@ -46,7 +45,7 @@ export function CreateIncomeDialogTrigger({
 	showKbd = true,
 	...props
 }: ButtonProps & { showKbd?: boolean }) {
-	const setDialog = useSetAtom(createIncomeDialogAtom);
+	const setDialog = createIncomeDialog.set;
 
 	return (
 		<Button size="sm" variant="outline" {...props} onClick={() => setDialog({ state: true })}>
@@ -75,7 +74,7 @@ function CreateIncomeForm() {
 	const { slug } = routeApi.useParams();
 	const wallets = useLiveQueryWallets();
 	const mutation = useCreateIncome();
-	const setDialog = useSetAtom(createIncomeDialogAtom);
+	const setDialog = createIncomeDialog.set;
 	const draft = useValue(draftIncome$);
 	const setDraft = draftIncome$.set;
 
@@ -234,7 +233,7 @@ function CreateIncomeForm() {
 }
 
 export function DeleteIncome({ id }: { id: string }) {
-	const setDialog = useSetAtom(deleteIncomeDialogAtom);
+	const setDialog = deleteIncomeDialog.set;
 
 	return (
 		<Tooltip>
@@ -258,7 +257,8 @@ export function DeleteIncome({ id }: { id: string }) {
 export function DeleteIncomeDialogContent() {
 	const { onSelectIncome } = useSelectedIncome();
 	const mutation = useDeleteIncome();
-	const [dialog, setDialog] = useAtom(deleteIncomeDialogAtom);
+	const dialog = useValue(deleteIncomeDialog.$);
+	const setDialog = deleteIncomeDialog.set;
 
 	const onDelete = async () => {
 		if (!dialog?.data?.id) {

--- a/apps/app/src/components/layouts/workspace-switcher.tsx
+++ b/apps/app/src/components/layouts/workspace-switcher.tsx
@@ -13,9 +13,8 @@ import { SidebarMenuButton } from "@hoalu/ui/sidebar";
 import { cn } from "@hoalu/ui/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link, useParams } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
 
-import { createWorkspaceDialogAtom } from "#app/atoms/index.ts";
+import { createWorkspaceDialog } from "#app/atoms/index.ts";
 import { HotKey } from "#app/components/hotkey.tsx";
 import { S3WorkspaceLogo } from "#app/components/workspace.tsx";
 import { KEYBOARD_SHORTCUTS } from "#app/helpers/constants.ts";
@@ -32,7 +31,7 @@ interface Props {
 export function WorkspaceSwitcher({ selectedWorkspace }: Props) {
 	const { data: workspaces } = useSuspenseQuery(listWorkspacesOptions());
 	const params = useParams({ from: "/_dashboard/$slug" });
-	const setDialog = useSetAtom(createWorkspaceDialogAtom);
+	const setDialog = createWorkspaceDialog.set;
 
 	return (
 		<DropdownMenu>

--- a/apps/app/src/components/providers/dialog-provider.tsx
+++ b/apps/app/src/components/providers/dialog-provider.tsx
@@ -48,8 +48,9 @@ export function DialogProvider(props: PropsWithChildren) {
 	const currentDialog = useValue(currentDialog$);
 
 	const handleOpenChange = (open: boolean) => {
-		dialog$.open.set(open);
-		if (!open) {
+		if (open) {
+			dialog$.open.set(true);
+		} else {
 			wipeOutDialogs();
 		}
 	};

--- a/apps/app/src/components/providers/dialog-provider.tsx
+++ b/apps/app/src/components/providers/dialog-provider.tsx
@@ -5,15 +5,10 @@ import {
 	DialogPortal,
 	DialogViewport,
 } from "@hoalu/ui/dialog";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useValue } from "@legendapp/state/react";
 import { Suspense, type PropsWithChildren } from "react";
 
-import {
-	currentDialogAtom,
-	type DialogId,
-	dialogStateAtom,
-	wipeOutDialogsAtom,
-} from "#app/atoms/index.ts";
+import { currentDialog$, dialog$, type DialogId, wipeOutDialogs } from "#app/atoms/index.ts";
 import {
 	CreateCategoryDialogContent,
 	DeleteCategoryDialogContent,
@@ -49,14 +44,13 @@ import {
 import { CreateWorkspaceDialogContent, DeleteWorkspaceDialogContent } from "../workspace";
 
 export function DialogProvider(props: PropsWithChildren) {
-	const [open, setOpen] = useAtom(dialogStateAtom);
-	const currentDialog = useAtomValue(currentDialogAtom);
-	const wipeOutAllDialogs = useSetAtom(wipeOutDialogsAtom);
+	const open = useValue(dialog$.open);
+	const currentDialog = useValue(currentDialog$);
 
 	const handleOpenChange = (open: boolean) => {
-		setOpen(open);
+		dialog$.open.set(open);
 		if (!open) {
-			wipeOutAllDialogs();
+			wipeOutDialogs();
 		}
 	};
 

--- a/apps/app/src/components/providers/workspace-action-provider.tsx
+++ b/apps/app/src/components/providers/workspace-action-provider.tsx
@@ -1,17 +1,16 @@
 import { useValue } from "@legendapp/state/react";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import {
 	commandPaletteOpen$,
-	createCategoryDialogAtom,
-	createExpenseDialogAtom,
-	createIncomeDialogAtom,
-	createRecurringBillDialogAtom,
-	createWalletDialogAtom,
-	dialogStateAtom,
+	createCategoryDialog,
+	createExpenseDialog,
+	createIncomeDialog,
+	createRecurringBillDialog,
+	createWalletDialog,
+	dialog$,
 	resetDraftExpense,
 } from "#app/atoms/index.ts";
 import { CommandPalette } from "#app/components/command-palette/index.ts";
@@ -26,7 +25,7 @@ export function WorkspaceActionProvider({ children }: { children: React.ReactNod
 	const { slug } = routeApi.useParams();
 	const navigate = useNavigate();
 
-	const isAnyDialogOpen = useAtomValue(dialogStateAtom);
+	const isAnyDialogOpen = useValue(dialog$.open);
 	const allowShortcutNavigate = !isAnyDialogOpen;
 
 	useEffect(() => {
@@ -35,11 +34,11 @@ export function WorkspaceActionProvider({ children }: { children: React.ReactNod
 		}
 	}, [slug]);
 
-	const setExpenseOpen = useSetAtom(createExpenseDialogAtom);
-	const setIncomeOpen = useSetAtom(createIncomeDialogAtom);
-	const setWalletOpen = useSetAtom(createWalletDialogAtom);
-	const setCategoryOpen = useSetAtom(createCategoryDialogAtom);
-	const setRecurringBillOpen = useSetAtom(createRecurringBillDialogAtom);
+	const setExpenseOpen = createExpenseDialog.set;
+	const setIncomeOpen = createIncomeDialog.set;
+	const setWalletOpen = createWalletDialog.set;
+	const setCategoryOpen = createCategoryDialog.set;
+	const setRecurringBillOpen = createRecurringBillDialog.set;
 
 	const commandPaletteOpen = useValue(commandPaletteOpen$);
 

--- a/apps/app/src/components/queue-panel.tsx
+++ b/apps/app/src/components/queue-panel.tsx
@@ -8,10 +8,9 @@ import {
 import { XIcon } from "@hoalu/icons/tabler";
 import { Button } from "@hoalu/ui/button";
 import { cn } from "@hoalu/ui/utils";
-import { useSetAtom } from "jotai";
 import { useEffect, useRef, useState } from "react";
 
-import { createExpenseDialogAtom, scanQueueReviewDialogAtom } from "#app/atoms/dialogs.ts";
+import { createExpenseDialog, scanQueueReviewDialog } from "#app/atoms/dialogs.ts";
 import { draftExpense$, quickExpenseJobId$ } from "#app/atoms/expenses.ts";
 import { useQuickExpenseQueue, useReceiptScanQueue } from "#app/hooks/use-queue.ts";
 
@@ -59,7 +58,7 @@ function JobStatusBadge({ status, retryCount }: { status: JobStatus; retryCount:
 
 function ReceiptJobItem({ job }: { job: ReceiptScanJob }) {
 	const { retry, remove } = useReceiptScanQueue();
-	const setReviewDialog = useSetAtom(scanQueueReviewDialogAtom);
+	const setReviewDialog = scanQueueReviewDialog.set;
 
 	const handleReview = () => {
 		setReviewDialog({ state: true, data: { jobId: job.id } });
@@ -145,7 +144,7 @@ function QuickExpenseJobItem({ job }: { job: QuickExpenseJob }) {
 	const { retry, remove } = useQuickExpenseQueue();
 	const setDraft = draftExpense$.set;
 	const setQuickExpenseJobId = quickExpenseJobId$.set;
-	const setCreateDialog = useSetAtom(createExpenseDialogAtom);
+	const setCreateDialog = createExpenseDialog.set;
 
 	const handleReview = () => {
 		if (!job.result) return;

--- a/apps/app/src/components/quick-expenses/quick-expenses-dialog.tsx
+++ b/apps/app/src/components/quick-expenses/quick-expenses-dialog.tsx
@@ -1,13 +1,12 @@
 import { ZapIcon } from "@hoalu/icons/lucide";
 import { Button, type ButtonProps } from "@hoalu/ui/button";
 import { DialogHeader, DialogHeaderAction, DialogPopup, DialogTitle } from "@hoalu/ui/dialog";
-import { useSetAtom } from "jotai";
 
-import { quickExpenseDialogAtom } from "#app/atoms/dialogs.ts";
+import { quickExpenseDialog } from "#app/atoms/dialogs.ts";
 import { QuickExpensesForm } from "#app/components/quick-expenses/quick-expenses-form.tsx";
 
 export function QuickExpensesDialogTrigger(props: ButtonProps) {
-	const setQuickDialog = useSetAtom(quickExpenseDialogAtom);
+	const setQuickDialog = quickExpenseDialog.set;
 
 	return (
 		<Button size="sm" variant="outline" {...props} onClick={() => setQuickDialog({ state: true })}>
@@ -18,7 +17,7 @@ export function QuickExpensesDialogTrigger(props: ButtonProps) {
 }
 
 export function QuickExpensesDialogContent() {
-	const setQuickDialog = useSetAtom(quickExpenseDialogAtom);
+	const setQuickDialog = quickExpenseDialog.set;
 
 	const handleSubmitted = () => {
 		setQuickDialog({ state: false });

--- a/apps/app/src/components/receipt/receipt-scanner.tsx
+++ b/apps/app/src/components/receipt/receipt-scanner.tsx
@@ -2,10 +2,9 @@ import { FileTextIcon, UploadIcon, XIcon, AlertCircleIcon } from "@hoalu/icons/l
 import { Alert, AlertDescription, AlertTitle } from "@hoalu/ui/alert";
 import { Button } from "@hoalu/ui/button";
 import { cn } from "@hoalu/ui/utils";
-import { useSetAtom } from "jotai";
 import { useCallback, useRef, useState } from "react";
 
-import { scanReceiptDialogAtom } from "#app/atoms/dialogs.ts";
+import { scanReceiptDialog } from "#app/atoms/dialogs.ts";
 import { MAX_QUEUE_SIZE } from "#app/helpers/constants.ts";
 import {
 	useReceiptScanQueue,
@@ -89,7 +88,7 @@ export function ReceiptScanner() {
 	const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
 	const [isDragging, setIsDragging] = useState(false);
 	const [isEncoding, setIsEncoding] = useState(false);
-	const setScanDialog = useSetAtom(scanReceiptDialogAtom);
+	const setScanDialog = scanReceiptDialog.set;
 	const workspace = useWorkspace();
 	const { add } = useReceiptScanQueue();
 	const { isFull: isQueueFull, sharedRemainingSlots } = useQueueStatus();

--- a/apps/app/src/components/receipt/scan-queue-review-dialog.tsx
+++ b/apps/app/src/components/receipt/scan-queue-review-dialog.tsx
@@ -12,16 +12,13 @@ import {
 import { Input } from "@hoalu/ui/input";
 import { Label } from "@hoalu/ui/label";
 import { SelectNative } from "@hoalu/ui/select-native";
+import { useValue } from "@legendapp/state/react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useMemo, useState, useCallback, useEffect } from "react";
 
-import {
-	currentDialogAtom,
-	createExpenseDialogAtom,
-	scanQueueReviewDialogAtom,
-} from "#app/atoms/dialogs.ts";
+import { currentDialog$, createExpenseDialog, scanQueueReviewDialog } from "#app/atoms/dialogs.ts";
 import { scannedReceipts$, draftExpense$, scannedReceiptJobId$ } from "#app/atoms/expenses.ts";
 import { TransactionAmountInput } from "#app/components/forms/transaction-amount.tsx";
 import { extensions } from "#app/components/tiptap.tsx";
@@ -83,15 +80,15 @@ async function base64ToFile(base64: string, fileName: string, fileType: string):
 }
 
 export function ScanQueueReviewDialogContent() {
-	const currentDialog = useAtomValue(currentDialogAtom);
+	const currentDialog = useValue(currentDialog$);
 	const jobId = currentDialog?.data?.jobId as string | undefined;
 	const queue = useAtomValue(receiptScanQueue.queueAtom);
 	const workspace = useWorkspace();
 	const { data: categories } = useSuspenseQuery(categoriesQueryOptions(workspace.slug));
 	const setDraftExpense = draftExpense$.set;
 	const setScannedReceipts = scannedReceipts$.set;
-	const setCreateDialog = useSetAtom(createExpenseDialogAtom);
-	const setReviewDialog = useSetAtom(scanQueueReviewDialogAtom);
+	const setCreateDialog = createExpenseDialog.set;
+	const setReviewDialog = scanQueueReviewDialog.set;
 
 	const setScannedReceiptJobId = scannedReceiptJobId$.set;
 	const addJob = useSetAtom(receiptScanQueue.add);

--- a/apps/app/src/components/receipt/scan-receipt-dialog.tsx
+++ b/apps/app/src/components/receipt/scan-receipt-dialog.tsx
@@ -7,14 +7,13 @@ import {
 	DialogPopup,
 	DialogTitle,
 } from "@hoalu/ui/dialog";
-import { useSetAtom } from "jotai";
 
-import { scanReceiptDialogAtom } from "#app/atoms/dialogs.ts";
+import { scanReceiptDialog } from "#app/atoms/dialogs.ts";
 import { ReceiptScanner } from "#app/components/receipt/receipt-scanner.tsx";
 import { MAX_QUEUE_SIZE } from "#app/helpers/constants.ts";
 
 export function ScanReceiptDialogTrigger(props: ButtonProps) {
-	const setScanDialog = useSetAtom(scanReceiptDialogAtom);
+	const setScanDialog = scanReceiptDialog.set;
 
 	return (
 		<Button size="sm" variant="outline" {...props} onClick={() => setScanDialog({ state: true })}>

--- a/apps/app/src/components/recurring-bills/recurring-bill-actions.tsx
+++ b/apps/app/src/components/recurring-bills/recurring-bill-actions.tsx
@@ -9,15 +9,15 @@ import {
 	DialogTitle,
 } from "@hoalu/ui/dialog";
 import { Field, FieldGroup } from "@hoalu/ui/field";
+import { useValue } from "@legendapp/state/react";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { useAtom, useSetAtom } from "jotai";
 import * as z from "zod";
 
 import {
-	archiveRecurringBillDialogAtom,
-	createRecurringBillDialogAtom,
-	deleteRecurringBillDialogAtom,
-	unarchiveRecurringBillDialogAtom,
+	archiveRecurringBillDialog,
+	createRecurringBillDialog,
+	deleteRecurringBillDialog,
+	unarchiveRecurringBillDialog,
 } from "#app/atoms/index.ts";
 import { useAppForm } from "#app/components/forms/index.tsx";
 import { type SyncedRecurringBill } from "#app/components/recurring-bills/use-recurring-bills.ts";
@@ -58,7 +58,7 @@ export function CreateRecurringBillDialogTrigger({
 	showKbd = true,
 	...props
 }: ButtonProps & { showKbd?: boolean }) {
-	const setDialog = useSetAtom(createRecurringBillDialogAtom);
+	const setDialog = createRecurringBillDialog.set;
 	return (
 		<Button size="sm" {...props} onClick={() => setDialog({ state: true })}>
 			New recurring bill
@@ -109,7 +109,7 @@ const DOM_OPTIONS = Array.from({ length: 31 }, (_, i) => ({
 export function CreateRecurringBillForm({ defaultDate, onSuccess }: CreateRecurringBillFormProps) {
 	const workspace = useWorkspace();
 	const mutation = useCreateRecurringBill();
-	const setDialog = useSetAtom(createRecurringBillDialogAtom);
+	const setDialog = createRecurringBillDialog.set;
 	const wallets = useLiveQueryWallets();
 
 	if (!wallets.length) return null;
@@ -381,7 +381,8 @@ export function ArchiveRecurringBillDialogContent() {
 	const navigate = useNavigate();
 	const { slug } = useParams({ from: "/_dashboard/$slug" });
 	const mutation = useArchiveRecurringBill();
-	const [dialog, setDialog] = useAtom(archiveRecurringBillDialogAtom);
+	const dialog = useValue(archiveRecurringBillDialog.$);
+	const setDialog = archiveRecurringBillDialog.set;
 
 	const onDelete = async () => {
 		if (!dialog?.data?.id) {
@@ -415,7 +416,8 @@ export function ArchiveRecurringBillDialogContent() {
 
 export function UnarchiveRecurringBillDialogContent() {
 	const mutation = useUnarchiveRecurringBill();
-	const [dialog, setDialog] = useAtom(unarchiveRecurringBillDialogAtom);
+	const dialog = useValue(unarchiveRecurringBillDialog.$);
+	const setDialog = unarchiveRecurringBillDialog.set;
 
 	const onUnarchive = async () => {
 		if (!dialog?.data?.id) {
@@ -449,7 +451,8 @@ export function DeleteRecurringBillDialogContent() {
 	const navigate = useNavigate();
 	const { slug } = useParams({ from: "/_dashboard/$slug" });
 	const mutation = useDeleteRecurringBill();
-	const [dialog, setDialog] = useAtom(deleteRecurringBillDialogAtom);
+	const dialog = useValue(deleteRecurringBillDialog.$);
+	const setDialog = deleteRecurringBillDialog.set;
 
 	const billTitle = dialog?.data?.title ?? "this bill";
 

--- a/apps/app/src/components/recurring-bills/recurring-bill-details.tsx
+++ b/apps/app/src/components/recurring-bills/recurring-bill-details.tsx
@@ -8,12 +8,11 @@ import {
 import { XIcon } from "@hoalu/icons/tabler";
 import { Button } from "@hoalu/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hoalu/ui/tooltip";
-import { useSetAtom } from "jotai";
 
 import {
-	archiveRecurringBillDialogAtom,
-	deleteRecurringBillDialogAtom,
-	unarchiveRecurringBillDialogAtom,
+	archiveRecurringBillDialog,
+	deleteRecurringBillDialog,
+	unarchiveRecurringBillDialog,
 } from "#app/atoms/index.ts";
 import { HotKey } from "#app/components/hotkey.tsx";
 import { EditRecurringBillForm } from "#app/components/recurring-bills/recurring-bill-actions.tsx";
@@ -36,9 +35,9 @@ export function RecurringBillDetailPanel({
 	canGoUp,
 	canGoDown,
 }: RecurringBillDetailPanelProps) {
-	const setArchiveDialog = useSetAtom(archiveRecurringBillDialogAtom);
-	const setUnarchiveDialog = useSetAtom(unarchiveRecurringBillDialogAtom);
-	const setDeleteDialog = useSetAtom(deleteRecurringBillDialogAtom);
+	const setArchiveDialog = archiveRecurringBillDialog.set;
+	const setUnarchiveDialog = unarchiveRecurringBillDialog.set;
+	const setDeleteDialog = deleteRecurringBillDialog.set;
 
 	return (
 		<div className="bg-card text-card-foreground flex h-[calc(100vh-94px)] flex-col overflow-auto">

--- a/apps/app/src/components/recurring-bills/recurring-bill-list.tsx
+++ b/apps/app/src/components/recurring-bills/recurring-bill-list.tsx
@@ -11,13 +11,12 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@hoalu/ui/empt
 import { cn } from "@hoalu/ui/utils";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { type ColumnDef } from "@tanstack/react-table";
-import { useSetAtom } from "jotai";
 import { memo, useCallback, useMemo, type MutableRefObject, type ReactNode } from "react";
 
 import {
-	archiveRecurringBillDialogAtom,
-	deleteRecurringBillDialogAtom,
-	unarchiveRecurringBillDialogAtom,
+	archiveRecurringBillDialog,
+	deleteRecurringBillDialog,
+	unarchiveRecurringBillDialog,
 } from "#app/atoms/index.ts";
 import { CurrencyValue } from "#app/components/currency-value.tsx";
 import {
@@ -93,9 +92,9 @@ function BillGroupHeader({
 }
 
 function RecurringBillContent(props: SyncedAllRecurringBill) {
-	const setArchiveDialog = useSetAtom(archiveRecurringBillDialogAtom);
-	const setUnarchiveDialog = useSetAtom(unarchiveRecurringBillDialogAtom);
-	const setDeleteDialog = useSetAtom(deleteRecurringBillDialogAtom);
+	const setArchiveDialog = archiveRecurringBillDialog.set;
+	const setUnarchiveDialog = unarchiveRecurringBillDialog.set;
+	const setDeleteDialog = deleteRecurringBillDialog.set;
 
 	const repeatLabel =
 		AVAILABLE_REPEAT_OPTIONS.find((o) => o.value === props.repeat)?.label ?? props.repeat;

--- a/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
+++ b/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
@@ -11,9 +11,8 @@ import {
 } from "@hoalu/ui/dropdown-menu";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@hoalu/ui/empty";
 import { cn } from "@hoalu/ui/utils";
-import { useSetAtom } from "jotai";
 
-import { createExpenseDialogAtom, draftExpense$, logPayment$ } from "#app/atoms/index.ts";
+import { createExpenseDialog, draftExpense$, logPayment$ } from "#app/atoms/index.ts";
 import { CurrencyValue } from "#app/components/currency-value.tsx";
 import { createCategoryTheme } from "#app/helpers/colors.ts";
 import { useArchiveRecurringBill } from "#app/services/mutations.ts";
@@ -167,7 +166,7 @@ interface UpcomingBillRowProps {
 
 function UpcomingBillRow({ bill }: UpcomingBillRowProps) {
 	const archive = useArchiveRecurringBill();
-	const setDialog = useSetAtom(createExpenseDialogAtom);
+	const setDialog = createExpenseDialog.set;
 	const setDraft = draftExpense$.set;
 	const setLogPayment = logPayment$.set;
 

--- a/apps/app/src/components/wallets/wallet-actions.tsx
+++ b/apps/app/src/components/wallets/wallet-actions.tsx
@@ -22,14 +22,10 @@ import {
 } from "@hoalu/ui/dropdown-menu";
 import { Field, FieldGroup } from "@hoalu/ui/field";
 import { cn } from "@hoalu/ui/utils";
+import { useValue } from "@legendapp/state/react";
 import { useQuery } from "@tanstack/react-query";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
-import {
-	createWalletDialogAtom,
-	deleteWalletDialogAtom,
-	editWalletDialogAtom,
-} from "#app/atoms/index.ts";
+import { createWalletDialog, deleteWalletDialog, editWalletDialog } from "#app/atoms/index.ts";
 import { useAppForm } from "#app/components/forms/index.tsx";
 import { HotKey } from "#app/components/hotkey.tsx";
 import { WarningMessage } from "#app/components/warning-message.tsx";
@@ -47,7 +43,7 @@ import { walletWithIdQueryOptions } from "#app/services/query-options.ts";
 import type { WalletTypeSchema } from "@hoalu/schema/schema";
 
 export function CreateWalletDialogTrigger() {
-	const setDialog = useSetAtom(createWalletDialogAtom);
+	const setDialog = createWalletDialog.set;
 
 	return (
 		<Button size="sm" onClick={() => setDialog({ state: true })}>
@@ -76,7 +72,7 @@ function CreateWalletForm() {
 	const {
 		metadata: { currency: workspaceCurrency },
 	} = useWorkspace();
-	const setDialog = useSetAtom(createWalletDialogAtom);
+	const setDialog = createWalletDialog.set;
 	const mutation = useCreateWallet();
 
 	const form = useAppForm({
@@ -152,7 +148,7 @@ function EditWalletForm(props: { id: string }) {
 	const workspace = useWorkspace();
 	const { data: wallet } = useQuery(walletWithIdQueryOptions(workspace.slug, props.id));
 	const mutation = useEditWallet();
-	const setDialog = useSetAtom(editWalletDialogAtom);
+	const setDialog = editWalletDialog.set;
 
 	const form = useAppForm({
 		defaultValues: {
@@ -254,7 +250,7 @@ function EditWalletForm(props: { id: string }) {
 }
 
 export function EditWalletDialogContent() {
-	const dialog = useAtomValue(editWalletDialogAtom);
+	const dialog = useValue(editWalletDialog.$);
 
 	return (
 		<DialogPopup className="sm:max-w-[480px]">
@@ -268,7 +264,8 @@ export function EditWalletDialogContent() {
 }
 
 export function DeleteWalletDialogContent() {
-	const [dialog, setDialog] = useAtom(deleteWalletDialogAtom);
+	const dialog = useValue(deleteWalletDialog.$);
+	const setDialog = deleteWalletDialog.set;
 	const mutation = useDeleteWallet();
 	const onDelete = async () => {
 		if (!dialog?.data?.id) {
@@ -300,8 +297,8 @@ export function DeleteWalletDialogContent() {
 }
 
 export function WalletDropdownMenuWithModal({ id }: { id: string }) {
-	const setEditDialog = useSetAtom(editWalletDialogAtom);
-	const setDeleteDialog = useSetAtom(deleteWalletDialogAtom);
+	const setEditDialog = editWalletDialog.set;
+	const setDeleteDialog = deleteWalletDialog.set;
 
 	return (
 		<DropdownMenu>

--- a/apps/app/src/components/workspace.tsx
+++ b/apps/app/src/components/workspace.tsx
@@ -1,6 +1,6 @@
+import { PlusIcon } from "@hoalu/icons/lucide";
 import { slugify } from "@hoalu/ids/slugify";
 import { tryCatch } from "@hoalu/stdlib/try-catch";
-import { PlusIcon } from "@hoalu/icons/lucide";
 import { Avatar, AvatarFallback, AvatarImage } from "@hoalu/ui/avatar";
 import { Button, type ButtonProps } from "@hoalu/ui/button";
 import { DialogHeader, DialogHeaderAction, DialogPopup, DialogTitle } from "@hoalu/ui/dialog";
@@ -9,9 +9,8 @@ import { cn } from "@hoalu/ui/utils";
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
 import { cva, type VariantProps } from "class-variance-authority";
-import { useSetAtom } from "jotai";
 
-import { createWorkspaceDialogAtom, deleteWorkspaceDialogAtom } from "#app/atoms/index.ts";
+import { createWorkspaceDialog, deleteWorkspaceDialog } from "#app/atoms/index.ts";
 import { useAppForm } from "#app/components/forms/index.tsx";
 import { WarningMessage } from "#app/components/warning-message.tsx";
 import { AVAILABLE_CURRENCY_OPTIONS } from "#app/helpers/constants.ts";
@@ -33,7 +32,7 @@ export function CreateWorkspaceTrigger({
 	showKbd = true,
 	...props
 }: ButtonProps & { showKbd?: boolean }) {
-	const setDialog = useSetAtom(createWorkspaceDialogAtom);
+	const setDialog = createWorkspaceDialog.set;
 
 	return (
 		<Button size="sm" variant="default" {...props} onClick={() => setDialog({ state: true })}>
@@ -57,7 +56,7 @@ export function CreateWorkspaceDialogContent() {
 
 export function CreateWorkspaceForm() {
 	const mutation = useCreateWorkspace();
-	const setDialog = useSetAtom(createWorkspaceDialogAtom);
+	const setDialog = createWorkspaceDialog.set;
 
 	const form = useAppForm({
 		defaultValues: {
@@ -279,7 +278,7 @@ export function DeleteWorkspaceDialogContent() {
 function DeleteWorkspaceForm() {
 	const { slug } = routeApi.useParams();
 	const mutation = useDeleteWorkspace();
-	const setDialog = useSetAtom(deleteWorkspaceDialogAtom);
+	const setDialog = deleteWorkspaceDialog.set;
 
 	const form = useAppForm({
 		defaultValues: {

--- a/apps/app/src/routes/_dashboard/$slug/settings/workspace.tsx
+++ b/apps/app/src/routes/_dashboard/$slug/settings/workspace.tsx
@@ -2,9 +2,8 @@ import { Button } from "@hoalu/ui/button";
 import { toastManager } from "@hoalu/ui/toast";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
 
-import { deleteWorkspaceDialogAtom } from "#app/atoms/index.ts";
+import { deleteWorkspaceDialog } from "#app/atoms/index.ts";
 import { SettingCard } from "#app/components/cards.tsx";
 import { useFilesUpload } from "#app/components/files/use-files-upload.ts";
 import { InputWithCopy } from "#app/components/input-with-copy.tsx";
@@ -41,7 +40,7 @@ function RouteComponent() {
 		onUpload: handleUploadLogo,
 	});
 
-	const setDialog = useSetAtom(deleteWorkspaceDialogAtom);
+	const setDialog = deleteWorkspaceDialog.set;
 	const canDeleteWorkspace = authClient.workspace.checkRolePermission({
 		role: member.role as "member" | "admin" | "owner",
 		permission: {

--- a/apps/app/src/routes/_dashboard/index.tsx
+++ b/apps/app/src/routes/_dashboard/index.tsx
@@ -2,9 +2,8 @@ import { PlusIcon } from "@hoalu/icons/lucide";
 import { Card } from "@hoalu/ui/card";
 import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
 
-import { createWorkspaceDialogAtom } from "#app/atoms/index.ts";
+import { createWorkspaceDialog } from "#app/atoms/index.ts";
 import { WorkspaceCard } from "#app/components/cards.tsx";
 import { Greeting } from "#app/components/greeting.tsx";
 import { PageContent } from "#app/components/layouts/page-content.tsx";
@@ -35,7 +34,7 @@ export const Route = createFileRoute("/_dashboard/")({
 function RouteComponent() {
 	const { data: workspaces } = useSuspenseQuery(listWorkspacesOptions());
 	const { data: summaries } = useQuery(listWorkspaceSummariesOptions());
-	const setDialog = useSetAtom(createWorkspaceDialogAtom);
+	const setDialog = createWorkspaceDialog.set;
 	const summaryMap = new Map((summaries || []).map((s) => [s.id, s]));
 
 	return (

--- a/apps/app/src/services/mutations.ts
+++ b/apps/app/src/services/mutations.ts
@@ -1,15 +1,10 @@
 import { toastManager } from "@hoalu/ui/toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { useSetAtom } from "jotai";
 import { WebHaptics } from "web-haptics";
 
 import { draftIncome$ } from "#app/atoms/incomes.ts";
-import {
-	createExpenseDialogAtom,
-	draftExpense$,
-	createIncomeDialogAtom,
-} from "#app/atoms/index.ts";
+import { createExpenseDialog, draftExpense$, createIncomeDialog } from "#app/atoms/index.ts";
 import { apiClient } from "#app/lib/api-client.ts";
 import { authClient } from "#app/lib/auth-client.ts";
 import {
@@ -467,7 +462,7 @@ export function useDeleteIncome() {
 }
 
 export function useDuplicateIncome() {
-	const setDialog = useSetAtom(createIncomeDialogAtom);
+	const setDialog = createIncomeDialog.set;
 	const setDraft = draftIncome$.set;
 
 	const mutation = useMutation({
@@ -803,7 +798,7 @@ export function useDeleteEvent() {
 }
 
 export function useDuplicateExpense() {
-	const setDialog = useSetAtom(createExpenseDialogAtom);
+	const setDialog = createExpenseDialog.set;
 	const setDraft = draftExpense$.set;
 
 	const mutation = useMutation({


### PR DESCRIPTION
Replace the jotai atoms-inside-atoms dialog manager (dialogManagerAtom + per-id createDialogAtom factory, ~140 lines) with a single flat dialog$ observable ({ currentId, data, open }), a computed currentDialog$, a wipeOutDialogs() helper, and per-dialog controllers exposing $ (computed { id, data } | null) and set({ state, data }).

Consumers read via useValue(xDialog.$) and write via xDialog.set, keeping the existing { state: true/false } call shape. Files keep jotai only for the separate task-queue subsystem.