### PR TITLE
feat: add finance-lessons course + fly.io hosting

### DIFF
--- a/finance-lessons/.dockerignore
+++ b/finance-lessons/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+fly.toml
+NOTES.md
+learning-records/
+.git

--- a/finance-lessons/Dockerfile
+++ b/finance-lessons/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html

--- a/finance-lessons/MISSION.md
+++ b/finance-lessons/MISSION.md
@@ -1,0 +1,42 @@
+# Mission: Personal & Family Money Management (grounded in the Hoalu app)
+
+## Why
+
+The user is building **Hoalu** — a personal/family expense & income management app — yet learned
+the app's design by intuition, not from a grounding in how money management actually works. They
+want to (a) learn sound personal & family finance so they can run their own household's money
+properly, and (b) use that knowledge to see what Hoalu gets wrong or omits, and how to fix it from
+a **user & financial** perspective (not a code-quality perspective). The outcome: a household that
+is run well, and an app that genuinely helps people run theirs.
+
+## Success looks like
+
+- Can explain the core money-management framework in plain language: **balance sheet** (net worth),
+  **cash flow** (income/expense/savings rate), **budgeting**, **debt**, **investing**, and how they fit together.
+- Has a prioritised, financially-reasoned list of what is **wrong or missing** in Hoalu today, and a
+  concept-level direction for each fix (not code).
+- Can look at any feature in any finance app and judge whether it serves the user's money or just
+  looks busy.
+- Begins applying the framework to their own family's finances (their own wallet structure,
+  savings rate, net-worth picture).
+
+## Constraints
+
+- **No code lessons.** The user is uninterested in learning about the code; concepts and
+  user/financial perspective only. (The codebase is read by the teacher to ground lessons, not taught.)
+- **Jurisdiction: Vietnam (confirmed).** The household earns and spends primarily in VND; USD is
+  used for online payments (SaaS, international services). US-centric tax/retirement content
+  (401k/IRA, r/personalfinance flowchart) does NOT apply — Vietnam-specific resources are needed
+  for tax (PIT), social insurance (BHXH), and investing (VN30, local securities). Treat
+  jurisdiction-specific topics as a confirmed sub-track to ground Lessons 9, 12–13.
+- Lessons must tie back to Hoalu where possible — every concept should either explain something
+  the app does, or expose something it should do.
+- Family scope: may include multi-person household finances (the app has workspaces/members).
+
+## Out of scope
+
+- Writing, reviewing, or debugging Hoalu's code (the user explicitly excluded this).
+- Jurisdiction-specific tax or legal advice before the user confirms their country.
+- Becoming a certified financial planner / giving specific investment product recommendations.
+- Corporate finance, accounting (double-entry bookkeeping as a profession), or business accounting
+  beyond what a household needs.

--- a/finance-lessons/NOTES.md
+++ b/finance-lessons/NOTES.md
@@ -1,0 +1,55 @@
+# Notes
+
+## User preferences
+
+- **No code lessons.** The user is a developer building Hoalu but explicitly does not want to learn
+  about the code. Read the codebase to ground lessons; never teach the code itself. When pointing out
+  what's wrong in the app, frame it as "user/financial perspective" and "what the app should do," not
+  "how to fix the code."
+- **Family scope.** The user said "my/my family money." Lessons should consider multi-person household
+  finances where relevant (the app's workspace/member model supports this).
+
+## Open questions for the user
+
+- ~~**Jurisdiction.**~~ **RESOLVED: Vietnam.** The household earns and spends primarily in VND;
+  USD is used for online payments (SaaS, international services). US-centric tax/retirement content
+  does not apply.
+- ~~**Currencies in use.**~~ **RESOLVED: VND primary, USD for online payments.** This makes
+  Lesson 9 (multi-currency) directly relevant — the household has real USD exposure to convert and
+  track. The SBV central rate (sbv.gov.vn) is the canonical FX source.
+- **Current financial fluency.** Has the user read any personal-finance books before, or is this
+  greenfield? (Affects the starting zone of proximal development.) **Still open — ask.**
+- **Vietnamese-language high-trust sources.** The user is Vietnamese and may know better local
+  resources than I can find (PIT, BHXH, VN30 investing). Ask before asserting.
+
+## Working notes
+
+- The codebase audit (see `reference/hoalu-financial-audit.html`) is the single most useful grounding
+  document. Every concept lesson can point back to a concrete gap or defect it finds.
+- The biggest financially-impactful defects to build lessons around, in priority order:
+  1. No wallet balances at all → cannot show cash position or net worth (the core stock concept).
+  2. Credit cards modeled as plain wallets → cannot represent debt.
+  3. Cash-flow chart "balance" starts from 0 each period → misleading; not a real balance.
+  4. No per-category budgets → no budgeting system.
+  5. No transfers between accounts → moving money is impossible.
+  6. FX correctness: single conversion date for monthly sums, `created_at` vs `date` lookup, silent
+     zeroing when a rate is missing.
+  7. Recurring-bill `dueDay=0` validation gap; "one-time recurring bill" contradiction.
+  8. Income `repeat` field is decorative (no occurrence generation, no `recurringBillId`).
+- Curriculum arc (knowledge → app audit → improvement direction):
+  1. Stock vs Flow (balance sheet vs cash flow) — the foundational distinction Hoalu is half-blind to.
+  2. The balance sheet: assets, liabilities, net worth.
+  3. Wallets & accounts done right (checking/savings/credit-card/investment/debt).
+  4. Credit cards as debt instruments.
+  5. Cash flow & the savings rate.
+  6. Transfers are neither income nor expense.
+  7. Budgeting systems (zero-based / envelope / 50-30-20).
+  8. Recurring bills & subscriptions done right.
+  9. Multi-currency done right. **VIETNAM-GROUNDED:** SBV central rate is the canonical FX source;
+     the household's USD online spending makes this lesson directly practical.
+  10. Savings goals & sinking funds.
+  11. Debt & loans (amortization, avalanche vs snowball).
+  12. Investing basics & net-worth growth. **Needs Vietnam grounding:** VN30 index funds, local
+      securities accounts, BHXH — find high-trust sources before refining.
+  13. Financial independence & the 4% rule. **Needs Vietnam grounding:** no 401k/IRA; retirement is
+      BHXH + voluntary; the 4% rule's universal maths holds but the investable vehicles differ.

--- a/finance-lessons/RESOURCES.md
+++ b/finance-lessons/RESOURCES.md
@@ -1,0 +1,91 @@
+# Personal & Family Money Management Resources
+
+> High-trust sources only. Knowledge is drawn from here, not from parametric guesswork.
+> Communities listed under Wisdom are for the user to verify and join on their own terms.
+
+## Knowledge — Foundational books
+
+- [Book: _Your Money or Your Life_ — Vicki Robin & Joe Dominguez](https://www.penguinrandomhouse.com/books/175401/your-money-or-your-life-by-vicki-robin-and-joe-dominguez/)
+  The foundational "money = life energy" framework. Teaches tracking every penny, the **crossover point**
+  (when passive income exceeds expenses), and net-worth-over-time thinking. Use for: the philosophy of
+  tracking, net worth, financial independence. Directly relevant to Hoalu's missing net-worth feature.
+
+- [Book: _I Will Teach You to Be Rich_ — Ramit Sethi](https://www.iwillteachyoutoberich.com/)
+  A practical, automated personal-finance **system**: checking + savings + credit-card + investment
+  account architecture, automation, and "conscious spending." Use for: account architecture, automation,
+  the "Rich Life" framing. Directly relevant to Hoalu's wallet model and credit-card gap.
+
+- [Book: _The Psychology of Money_ — Morgan Housel](https://www.morganhousel.com/the-psychology-of-money)
+  Timeless essays on behaviour, compounding, risk, and why reasonable beats rational. Use for: the
+  behavioural layer that no app feature can substitute for.
+
+- [Book: _The Simple Path to Wealth_ — J.L. Collins](https://www.jlcollinsnh.com/)
+  Index investing, the **4% rule**, and "F-you money." Use for: investing & financial independence.
+  Relevant once Hoalu considers investment/net-worth-growth tracking.
+
+- [Book: _The Millionaire Next Door_ — Thomas J. Stanley & William D. Danko](https://gauss.wordpress.ncsu.edu/files/2020/08/The-Millionaire-Next-Door.pdf)
+  Wealth accumulation vs. income; net worth as the true measure. Use for: the net-worth-vs-income
+  distinction that Hoalu currently cannot show.
+
+## Knowledge — Free / online
+
+- [Khan Academy: Personal Finance](https://www.khanacademy.org/college-careers-more/personal-finance)
+  Free, structured course covering budgeting, saving, taxes, investing basics, and credit.
+  Use for: a grounded baseline curriculum; cross-check any concept the lessons introduce.
+
+- [Investopedia](https://www.investopedia.com/)
+  Reference dictionary for financial terms. Use for: looking up definitions, NOT as a course.
+
+- [Bogleheads Wiki — Investment Philosophy](https://www.bogleheads.org/wiki/Bogleheads%C2%AE_investment_philosophy)
+  Evidence-based index-investing reference: three-fund portfolio, 4% rule, withdrawal strategies.
+  Use for: investing concepts and the FI maths.
+
+## Wisdom — Communities
+
+- [Bogleheads Forum](https://www.bogleheads.org/forum/)
+  High-signal investing community with strong moderation against stock-picking hype. Use for:
+  portfolio critique, withdrawal-strategy reality checks.
+
+- [r/personalfinance (Reddit)](https://www.reddit.com/r/personalfinance/wiki/index/)
+  Large, well-moderated community with a wiki and the "Prime Directive" money flowchart.
+  **US-centric** — the flowchart won't map 1:1 outside the US. Use for: practical money questions,
+  sanity-checking decisions.
+
+- [r/financialindependence (Reddit)](https://www.reddit.com/r/financialindependence/)
+  FIRE (Financial Independence / Retire Early) community. Use for: savings-rate and withdrawal
+  discussions, long-term thinking.
+
+- [YNAB Method & Community](https://www.youneedabudget.com/method/)
+  The zero-based / envelope-budgeting philosophy, explained by its originator. Use for: the
+  budgeting mental model that Hoalu's missing per-category budgets would need.
+
+## Knowledge — Vietnam-specific (jurisdiction confirmed)
+
+- [State Bank of Vietnam — Official exchange rates (Tỷ giá)](https://www.sbv.gov.vn/t%E1%BB%B7-gi%C3%A1)
+  The central bank publishes the official VND/USD central rate ("tỷ giá trung tâm") and reference
+  cross-rates, in weekly windows. Use for: the canonical FX source for Hoalu's multi-currency
+  pipeline (Lesson 9) — this is the rate a Vietnam-based household should convert USD online
+  spending at, dated to the transaction's week.
+
+- [General Department of Taxation (Tổng cục Thuế) — tax.gov.vn](https://tax.gov.vn)
+  Official source for Vietnam Personal Income Tax (PIT) rules, brackets, and deductible items.
+  Use for: grounding any tax-tracking feature. **Vietnamese-language; verify current brackets
+  against the latest decree — PIT changes frequently.** (To be annotated in detail when tax
+  lessons come up.)
+
+## Gaps
+
+- **No high-trust English Vietnam PIT primer confirmed.** PwC/Big-4 "Vietnam tax facts" pages
+  rotate URLs and 404 often. Need a stable, current overview of Vietnam PIT (brackets, deductibles,
+  foreign-income treatment) before grounding tax-tracking. The user may know a better
+  Vietnamese-language source — ask.
+- **No Vietnam investing primer confirmed.** Need a high-trust source on VN30 index funds, local
+  securities accounts, and how a Vietnam resident invests domestically vs. internationally
+  (capital-controls and foreign-account rules matter). Brokerage sites (SSI, VNDirect, TCBS) are
+  commercial, not neutral — use only to understand mechanics, not for strategy.
+- **No Vietnam retirement/social-insurance (BHXH) resource.** Vietnam has no 401k/IRA equivalent;
+  retirement is BHXH (state social insurance) plus voluntary. Need a source on BHXH benefit
+  calculation and voluntary top-ups before the FI lessons (12–13) can be Vietnam-grounded.
+- **Multi-currency household risk.** Confirmed relevant: the household spends USD online (SaaS,
+  international services) while earning in VND. Need a resource on managing VND/USD exposure at the
+  household level (the managed-float regime means the rate moves in steps, not freely).

--- a/finance-lessons/assets/lesson.css
+++ b/finance-lessons/assets/lesson.css
@@ -1,0 +1,313 @@
+/* Hoalu Money-Management Lessons — shared stylesheet
+   Design goal: Tufte-like, print-friendly, readable, one consistent course. */
+
+:root {
+	--ink: #1a1a1a;
+	--ink-soft: #444;
+	--ink-faint: #777;
+	--rule: #d8d4cc;
+	--rule-soft: #ece8df;
+	--paper: #fbfaf7;
+	--paper-warm: #f4f1ea;
+	--accent: #7a4a2d;        /* warm sienna for headings & links */
+	--accent-soft: #b07a52;
+	--stock: #2d5a7a;         /* blue — "stock" / point-in-time */
+	--flow: #7a4a2d;          /* sienna — "flow" / period */
+	--good: #2f6b3e;
+	--bad: #9a3b2c;
+	--warn: #8a6d1f;
+	--serif: ui-serif, Georgia, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+	--sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+	--mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+	--measure: 66ch;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 18px; -webkit-text-size-adjust: 100%; }
+
+body {
+	margin: 0;
+	font-family: var(--serif);
+	color: var(--ink);
+	background: var(--paper);
+	line-height: 1.6;
+	font-feature-settings: "kern", "liga", "onum";
+}
+
+/* Layout ----------------------------------------------------------------- */
+
+.lesson {
+	max-width: var(--measure);
+	margin: 0 auto;
+	padding: 4rem 1.25rem 6rem;
+}
+
+.lesson > * { max-width: var(--measure); }
+
+/* Wide elements (tables, figures): wider than the text measure but
+   centered and capped to the viewport. Qualified with .lesson so they
+   beat the `.lesson > *` measure cap, and centered with auto margins
+   (no negative-margin full-bleed → no scrollbar asymmetry, no drift). */
+.lesson .wide, .lesson figure, .lesson table {
+	margin-inline: auto;
+	max-width: min(100vw - 1rem, 52rem);
+	width: 100%;
+}
+@media (max-width: 880px) {
+	.lesson .wide, .lesson figure, .lesson table {
+		max-width: 100%;
+	}
+}
+
+/* Header ----------------------------------------------------------------- */
+
+.lesson-header {
+	border-bottom: 1px solid var(--rule);
+	padding-bottom: 1.5rem;
+	margin-bottom: 2.5rem;
+}
+.lesson-kicker {
+	font-family: var(--sans);
+	font-size: 0.72rem;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--accent);
+	font-weight: 600;
+	margin: 0 0 0.5rem;
+}
+.lesson-header h1 {
+	font-family: var(--serif);
+	font-size: 2.1rem;
+	line-height: 1.15;
+	font-weight: 600;
+	margin: 0 0 0.6rem;
+	letter-spacing: -0.01em;
+}
+.lesson-meta {
+	font-family: var(--sans);
+	font-size: 0.8rem;
+	color: var(--ink-faint);
+	margin: 0;
+}
+
+/* Prose ------------------------------------------------------------------ */
+
+p { margin: 0 0 1.1rem; hyphens: auto; }
+h2 {
+	font-family: var(--serif);
+	font-size: 1.35rem;
+	font-weight: 600;
+	margin: 2.2rem 0 0.8rem;
+	line-height: 1.25;
+	letter-spacing: -0.005em;
+}
+h3 {
+	font-family: var(--sans);
+	font-size: 0.82rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--ink-soft);
+	font-weight: 600;
+	margin: 1.8rem 0 0.5rem;
+}
+em { font-style: italic; }
+strong { font-weight: 600; }
+a { color: var(--accent); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+a:hover { color: var(--ink); }
+
+ul, ol { margin: 0 0 1.1rem; padding-left: 1.4rem; }
+li { margin-bottom: 0.3rem; }
+li::marker { color: var(--accent-soft); }
+
+/* Marginal note (Tufte-style) ------------------------------------------- */
+
+aside.note {
+	float: right;
+	clear: right;
+	width: 42%;
+	margin: 0.2rem -2rem 1rem 1.5rem;
+	font-family: var(--sans);
+	font-size: 0.78rem;
+	line-height: 1.5;
+	color: var(--ink-soft);
+	border-left: 2px solid var(--accent-soft);
+	padding-left: 0.9rem;
+}
+aside.note b { color: var(--accent); }
+@media (max-width: 900px) {
+	aside.note { float: none; width: auto; margin: 1rem 0; }
+}
+
+/* Callout boxes ---------------------------------------------------------- */
+
+.callout {
+	border: 1px solid var(--rule);
+	background: var(--paper-warm);
+	border-radius: 4px;
+	padding: 1rem 1.25rem;
+	margin: 1.5rem 0;
+	font-size: 0.95rem;
+}
+.callout-title {
+	font-family: var(--sans);
+	font-size: 0.72rem;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	font-weight: 600;
+	margin: 0 0 0.5rem;
+}
+.callout-title.app { color: var(--accent); }
+.callout-title.def { color: var(--stock); }
+.callout-title.warn { color: var(--warn); }
+.callout-title.source { color: var(--good); }
+
+/* Key-value definition rows */
+.def-row { display: grid; grid-template-columns: 9rem 1fr; gap: 0.5rem 1rem; margin: 0.5rem 0; }
+.def-row dt { font-family: var(--sans); font-size: 0.78rem; color: var(--ink-faint); font-weight: 600; }
+.def-row dd { margin: 0; }
+
+/* Quiz ------------------------------------------------------------------- */
+
+.quiz {
+	border: 1px solid var(--rule);
+	border-radius: 5px;
+	padding: 1.5rem 1.5rem 1.25rem;
+	margin: 2rem 0;
+	background: var(--paper);
+}
+.quiz > h3 { margin-top: 0; }
+.quiz-score {
+	font-family: var(--sans);
+	font-size: 0.8rem;
+	color: var(--ink-faint);
+	margin: 0 0 1rem;
+}
+.quiz-item {
+	padding: 0.9rem 0;
+	border-top: 1px solid var(--rule-soft);
+}
+.quiz-item:first-of-type { border-top: none; }
+.quiz-prompt { margin: 0 0 0.6rem; font-size: 1.02rem; }
+.quiz-options { display: flex; gap: 0.6rem; flex-wrap: wrap; }
+.quiz-options button {
+	font-family: var(--sans);
+	font-size: 0.82rem;
+	font-weight: 600;
+	padding: 0.45rem 1rem;
+	border: 1px solid var(--rule);
+	background: var(--paper);
+	color: var(--ink-soft);
+	border-radius: 4px;
+	cursor: pointer;
+	letter-spacing: 0.02em;
+	transition: all 0.12s;
+}
+.quiz-options button:hover:not(:disabled) { border-color: var(--accent-soft); color: var(--ink); }
+.quiz-options button:disabled { cursor: default; opacity: 0.55; }
+.quiz-options button.correct {
+	background: var(--good); color: #fff; border-color: var(--good); opacity: 1;
+}
+.quiz-options button.wrong {
+	background: var(--bad); color: #fff; border-color: var(--bad); opacity: 1;
+}
+.quiz-feedback {
+	font-family: var(--sans);
+	font-size: 0.8rem;
+	margin: 0.55rem 0 0;
+	min-height: 1.1em;
+	color: var(--ink-soft);
+}
+.quiz-feedback.correct { color: var(--good); }
+.quiz-feedback.wrong { color: var(--bad); }
+.quiz-complete {
+	font-family: var(--sans);
+	font-size: 0.85rem;
+	font-weight: 600;
+	margin: 0.75rem 0 0;
+	padding-top: 0.75rem;
+	border-top: 1px solid var(--rule);
+	color: var(--accent);
+}
+
+/* Table ------------------------------------------------------------------ */
+
+table {
+	border-collapse: collapse;
+	font-family: var(--sans);
+	font-size: 0.82rem;
+	width: 100%;
+}
+th, td {
+	text-align: left;
+	padding: 0.55rem 0.8rem;
+	border-bottom: 1px solid var(--rule);
+	vertical-align: top;
+}
+th { font-weight: 600; color: var(--ink-soft); border-bottom: 2px solid var(--rule); }
+tbody tr:last-child td { border-bottom: none; }
+
+/* Figure ----------------------------------------------------------------- */
+
+figure { padding: 0; }
+figcaption {
+	font-family: var(--sans);
+	font-size: 0.78rem;
+	color: var(--ink-faint);
+	padding: 0.5rem 1.25rem 0;
+	text-align: center;
+	margin: 0;
+}
+
+/* Diagram (inline SVG / styled boxes) ----------------------------------- */
+
+.diagram {
+	font-family: var(--sans);
+	font-size: 0.82rem;
+}
+.diagram-box {
+	border: 1.5px solid var(--ink);
+	border-radius: 5px;
+	padding: 0.7rem 0.9rem;
+	display: inline-block;
+	text-align: center;
+	background: var(--paper);
+}
+.diagram-box.stock { border-color: var(--stock); color: var(--stock); }
+.diagram-box.flow { border-color: var(--flow); color: var(--flow); }
+.diagram-arrow { color: var(--ink-faint); font-size: 1.1rem; }
+
+/* Footer ----------------------------------------------------------------- */
+
+.lesson-footer {
+	margin-top: 3rem;
+	padding-top: 1.5rem;
+	border-top: 1px solid var(--rule);
+	font-family: var(--sans);
+	font-size: 0.82rem;
+	color: var(--ink-soft);
+}
+.lesson-footer .questions {
+	background: var(--paper-warm);
+	border-left: 3px solid var(--accent);
+	padding: 0.9rem 1.1rem;
+	margin: 0 0 1.5rem;
+	border-radius: 0 4px 4px 0;
+}
+.lesson-footer .questions b { color: var(--accent); }
+.lesson-footer nav { display: flex; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.lesson-footer nav a { font-family: var(--sans); }
+
+hr.section { border: none; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+
+/* Print ------------------------------------------------------------------ */
+
+@media print {
+	body { background: #fff; font-size: 11pt; }
+	.lesson { max-width: none; padding: 0; }
+	.wide, figure, table { margin: 0; max-width: none; }
+	aside.note { float: none; width: auto; margin: 0.5rem 0; border-left-width: 2px; }
+	.quiz-options button { border: 1px solid #999; color: #333; }
+	a { color: #333; text-decoration: underline; }
+	.lesson-footer nav { display: none; }
+}

--- a/finance-lessons/assets/quiz.js
+++ b/finance-lessons/assets/quiz.js
@@ -1,0 +1,74 @@
+/* Hoalu lessons — reusable quiz widget.
+   Usage: a container with [data-quiz], containing one or more .quiz-item.
+   Each .quiz-item has:
+     - data-answer="X"      (the correct choice value)
+     - .quiz-prompt         (the question text)
+     - .quiz-options > button[data-choice="X"]
+     - .quiz-feedback       (filled in with feedback text)
+   Optional: .quiz-score (shows progress) and .quiz-complete (final score line).
+   Choices can be anything (stock/flow, yes/no, a/b/c...) — the widget is generic.
+   On click: immediate feedback, lock the item, and update the running score. */
+(function () {
+	"use strict";
+	function init(root) {
+		var quizzes = (root || document).querySelectorAll("[data-quiz]");
+		quizzes.forEach(function (quiz) {
+			var items = quiz.querySelectorAll(".quiz-item");
+			var answered = 0;
+			var correct = 0;
+			items.forEach(function (item) {
+				var answer = (item.getAttribute("data-answer") || "").trim();
+				var buttons = item.querySelectorAll(".quiz-options button");
+				var feedback = item.querySelector(".quiz-feedback");
+				var reason = (item.getAttribute("data-reason") || "").trim();
+				buttons.forEach(function (btn) {
+					btn.addEventListener("click", function () {
+						if (item.classList.contains("answered")) return;
+						var choice = (btn.getAttribute("data-choice") || "").trim();
+						var isCorrect = choice === answer;
+						item.classList.add("answered");
+						buttons.forEach(function (b) {
+							b.disabled = true;
+							if ((b.getAttribute("data-choice") || "").trim() === answer) b.classList.add("correct");
+						});
+						if (!isCorrect) btn.classList.add("wrong");
+						if (feedback) {
+							feedback.classList.toggle("correct", isCorrect);
+							feedback.classList.toggle("wrong", !isCorrect);
+							feedback.textContent = isCorrect
+								? "Correct." + (reason ? " " + reason : "")
+								: "Not quite — the answer is " + answer + "." + (reason ? " " + reason : "");
+						}
+						answered++;
+						if (isCorrect) correct++;
+						updateScore();
+					});
+				});
+			});
+			function updateScore() {
+				var score = quiz.querySelector(".quiz-score");
+				if (score) {
+					score.textContent = answered + " of " + items.length + " answered · " + correct + " correct";
+				}
+				if (answered === items.length) {
+					var done = quiz.querySelector(".quiz-complete");
+					if (done) {
+						var pct = Math.round((correct / items.length) * 100);
+						var perfect = quiz.getAttribute("data-msg-perfect") || "All correct.";
+						var good = quiz.getAttribute("data-msg-good") || "Good — " + correct + "/" + items.length + ". Review the misses below.";
+						var retry = quiz.getAttribute("data-msg-retry") || "Re-read the section above, then retry — " + correct + "/" + items.length + ".";
+						var msg = correct === items.length ? perfect : pct >= 60 ? good : retry;
+						done.textContent = msg;
+					}
+				}
+			}
+			updateScore();
+		});
+	}
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", function () { init(document); });
+	} else {
+		init(document);
+	}
+	window.HoaluQuiz = { init: init };
+})();

--- a/finance-lessons/fly.toml
+++ b/finance-lessons/fly.toml
@@ -1,0 +1,22 @@
+# fly.toml app configuration file generated for hoalu-finance-lessons on 2026-07-09T16:09:16+07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'hoalu-finance-lessons'
+primary_region = 'sin'
+
+[build]
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 1024

--- a/finance-lessons/index.html
+++ b/finance-lessons/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="refresh" content="0; url=lessons/index.html" />
+<title>Money Management for Hoalu</title>
+<style>body{font-family:system-ui,sans-serif;max-width:40rem;margin:8rem auto;padding:0 1.5rem;color:#1a1a1a}a{color:#7a4a2d}</style>
+</head>
+<body>
+<h1>Money Management for Hoalu</h1>
+<p>Redirecting to <a href="lessons/index.html">the course index</a>…</p>
+</body>
+</html>

--- a/finance-lessons/learning-records/0001-starting-point.md
+++ b/finance-lessons/learning-records/0001-starting-point.md
@@ -1,0 +1,15 @@
+# Starting point: developer building a finance app, learning the financial concepts fresh
+
+The user is the builder of Hoalu (a personal/family expense & income app) but explicitly wants to
+learn personal & family money management **concepts** — not code. They disclosed no prior
+formal finance education in the first session, so treat financial literacy as **greenfield** and
+build from the stock-vs-flow distinction upward. The app's current state is the grounding material:
+an audit was produced (see `../reference/hoalu-financial-audit.html`) showing the app is a competent
+expense-tracker but lacks the entire balance-sheet half (no wallet balances, no net worth, credit
+cards unmodeled, no transfers, no budgets).
+
+This matters for future sessions because: (1) every concept can be tied to a concrete app gap,
+keeping lessons out of the abstract; (2) the user's zone of proximal development starts at the
+foundational layer — do not assume familiarity with net worth, savings rate, or budgeting systems;
+(3) jurisdiction is unconfirmed (VND appears in the app → likely Vietnam) and gates all
+tax/retirement/currency lessons, so confirm before reaching that sub-track.

--- a/finance-lessons/learning-records/0002-curriculum-built.md
+++ b/finance-lessons/learning-records/0002-curriculum-built.md
@@ -1,0 +1,19 @@
+# Curriculum arc decided and built (13 lessons, single pass)
+
+The full course was authored in one pass: 13 lessons across four arcs — Foundations (stock/flow,
+balance sheet, accounts, credit cards), Cash-flow (savings rate, transfers, budgets), Operations
+(recurring bills, multi-currency, sinking funds), and the Long game (debt, investing, FI). Every
+lesson ties to a concrete Hoalu gap cited from `../reference/hoalu-financial-audit.html`, and each ends
+with an interactive drill (reusable `../assets/quiz.js`) plus a primary-source recommendation from
+`../RESOURCES.md`.
+
+Implications for future sessions:
+- The zone of proximal development now moves from *knowledge delivery* to *retrieval and
+  application*. Future sessions should favour **retrieval practice** (quizzing across lessons),
+  **interleaving** (mixing balance-sheet and cash-flow questions), and **applying** concepts to
+  the user's own household numbers — not re-explaining what the lessons already cover.
+- Three jurisdiction/currency questions remain open (see ../NOTES.md) and gate Lessons 9 and 12-13's
+  specifics. Do not refine those until the user confirms their country and currencies.
+- Once the user has worked through lessons, the natural next artifact is a **prioritised Hoalu
+  improvement spec** — turning the audit gaps into a ranked backlog from the user/financial
+  perspective. Wait for the user to demonstrate the concepts before co-writing it.

--- a/finance-lessons/learning-records/0003-jurisdiction-vietnam.md
+++ b/finance-lessons/learning-records/0003-jurisdiction-vietnam.md
@@ -1,0 +1,24 @@
+# Jurisdiction confirmed: Vietnam, VND-primary with USD online spending
+
+The user confirmed the household lives and pays tax in **Vietnam**, earns and spends primarily in
+**VND**, and uses **USD for online payments** (SaaS, international services). This resolves the two
+gating questions and reshapes the curriculum:
+
+- **Lesson 9 (multi-currency)** becomes directly practical, not theoretical — the household has real
+  recurring USD outflows to convert and track. The **State Bank of Vietnam** (sbv.gov.vn) is the
+  canonical source for the official VND/USD central rate, published in weekly windows. Hoalu's FX
+  pipeline should convert USD spending at the SBV rate valid for the transaction's date (the
+  lesson's "rate-at-transaction-date" principle maps cleanly onto SBV's weekly rate windows).
+- **US-centric content is demoted.** r/personalfinance's "Prime Directive" flowchart, 401k/IRA
+  framing, and US tax-advantaged accounts do NOT apply to this user. Do not cite them for tax or
+  retirement without an explicit "this is US-only, does not apply to you" caveat.
+- **Lessons 12–13 (investing, FI)** need Vietnam grounding before refinement: Vietnam has no
+  401k/IRA equivalent; retirement is BHXH (state social insurance) + voluntary; investable vehicles
+  are domestic (VN30 index funds, local securities accounts) with capital-control constraints on
+  international investing. The 4%-rule maths is universal, but the vehicles that generate the
+  returns are jurisdiction-specific.
+
+Implications: this is a decision-grade shift. Future sessions on tax/retirement/investing must find
+high-trust Vietnam-specific sources first (PIT, BHXH, VN30) — never assert from US-centric
+parametric knowledge. The user is Vietnamese and may know better local sources than the agent can
+find; ask before asserting. See ../RESOURCES.md "Gaps" for what is still unverified.

--- a/finance-lessons/lessons/0001-stock-vs-flow.html
+++ b/finance-lessons/lessons/0001-stock-vs-flow.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 1 — Stock vs Flow</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 1 · Foundations</p>
+	<h1>Stock vs. Flow: the one distinction your app is half-blind to</h1>
+	<p class="lesson-meta">Grounded in the <a href="../reference/hoalu-financial-audit.html">Hoalu Financial Audit</a> · ~8 minutes · tied to <a href="../MISSION.md">your mission</a></p>
+</header>
+
+<p>Every number in personal finance is one of two kinds. Learn to tell them apart and you will
+suddenly see <em>why</em> Hoalu feels incomplete — and what every real finance app must have that
+Hoalu does not.</p>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Stock</dt><dd>A quantity measured <strong>at a single point in time</strong>. "How much right now?" — your bank balance <em>today</em>, your debt <em>as of Dec 31</em>, your net worth <em>this moment</em>.</dd></div>
+	<div class="def-row"><dt>Flow</dt><dd>A quantity measured <strong>over a period of time</strong>. "How much moved during March?" — your salary <em>earned this month</em>, your groceries <em>spent this month</em>, your savings rate <em>this year</em>.</dd></div>
+</div>
+
+<p>The words come from physics, where the same split exists: the water <em>in</em> a bathtub is a
+stock (litres, now); the water <em>flowing through</em> the tap is a flow (litres per minute). A
+bathtub without a water level is useless — and so is a finance app that only counts the tap.</p>
+
+<h2>The two statements this maps to</h2>
+
+<p>Accountants formalise this split into two documents. You do not need to be an accountant, but
+you must know which one is which:</p>
+
+<table>
+	<thead><tr><th></th><th>Balance Sheet</th><th>Cash-Flow Statement</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Kind</strong></td><td>Stocks</td><td>Flows</td></tr>
+		<tr><td><strong>Question</strong></td><td>Where do I stand <em>right now</em>?</td><td>What moved <em>this month</em>?</td></tr>
+		<tr><td><strong>Contains</strong></td><td>Assets, liabilities → <strong>net worth</strong></td><td>Income, expenses → <strong>savings</strong></td></tr>
+		<tr><td><strong>Snapshot?</strong></td><td>Yes — a single date</td><td>No — a date <em>range</em></td></tr>
+	</tbody>
+</table>
+
+<p>Here is the crucial relationship: <strong>flows change stocks.</strong> Earn income (a flow in)
+and your bank balance (a stock) rises. Spend on groceries (a flow out) and it falls. The cash-flow
+statement is the <em>engine</em>; the balance sheet is the <em>scoreboard</em>. A household that
+only watches the engine and never the scoreboard cannot tell whether it is actually getting
+richer.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the half that is missing</p>
+	<p>Hoalu today is <strong>almost entirely a cash-flow app</strong>: it records expenses and income
+	(flows) and charts them over periods. What it lacks is the balance sheet:</p>
+	<ul>
+		<li><strong>No wallet balances</strong> — the <code>wallet</code> table has no balance column at all, so the app cannot say "you have X VND right now." (<a href="../reference/hoalu-financial-audit.html">Audit §1</a>)</li>
+		<li><strong>No net worth</strong> — no assets-vs-liabilities view, no net-worth-over-time series. (<a href="../reference/hoalu-financial-audit.html">Audit, missing-features table</a>)</li>
+		<li><strong>The dashboard "balance" is not a balance</strong> — the cash-flow chart starts from zero each period, so it shows period net flow dressed up as an account balance. Change the date range and the "balance" jumps, because nothing is carried forward. (<a href="../reference/hoalu-financial-audit.html">Audit §3</a>)</li>
+	</ul>
+	<p>That is the entire reason the app feels like a spending diary rather than a money
+	<em>manager</em>: it counts the tap, never the water level.</p>
+</div>
+
+<h2>The one win from this lesson</h2>
+
+<p>Look at <em>any</em> feature in <em>any</em> finance app and ask one question: <strong>is this
+number a stock or a flow?</strong> If a "balance" depends on which date range you picked, it is a
+flow pretending to be a stock — and that is a design smell. Real balances are point-in-time. Real
+flows are period-scoped. Hold that distinction and the rest of this course will slot into place.</p>
+
+<p>Now test it:</p>
+
+<div class="quiz" data-quiz>
+	<h3>Classify each: stock or flow?</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="stock" data-reason="It is money sitting in the account at one moment — a point-in-time quantity.">
+		<p class="quiz-prompt">The 50,000,000 ₫ sitting in your bank account right now.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="flow" data-reason="Salary earned during March is movement over a period — a flow.">
+		<p class="quiz-prompt">The 30,000,000 ₫ you earned in salary during March.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="stock" data-reason="Total debt owed as of a date is a liability at a point in time — a stock.">
+		<p class="quiz-prompt">Your total debt of 120,000,000 ₫ as of today.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="flow" data-reason="Groceries spent this month is movement over a period — a flow.">
+		<p class="quiz-prompt">The 8,000,000 ₫ you spent on groceries this month.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="stock" data-reason="Net worth on a specific date is the classic stock — the scoreboard at one moment.">
+		<p class="quiz-prompt">Your net worth of 250,000,000 ₫ on December 31st.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="flow" data-reason="A savings rate is a ratio of flows over a period — it has no meaning at a single instant.">
+		<p class="quiz-prompt">The 15% of income you saved this year.</p>
+		<div class="quiz-options">
+			<button data-choice="stock">Stock</button>
+			<button data-choice="flow">Flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.penguinrandomhouse.com/books/175401/your-money-or-your-life-by-vicki-robin-and-joe-dominguez/">Your Money or Your Life</a> — Vicki Robin &amp; Joe Dominguez.</strong>
+	The whole method turns on tracking every penny (flows) <em>so that</em> you can see your net worth
+	rise toward the "crossover point" (a stock). It is the clearest argument for why a finance app
+	must hold both halves — and it is the philosophical parent of the balance-sheet feature Hoalu
+	is missing.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> Anything unclear? "Why is net worth more important than income?"
+		"How can Hoalu show a real balance if it has no balance field?" "Is a credit limit a stock
+		or a flow?" — ask. This agent is your teacher across sessions; the answers steer the next lesson.
+	</div>
+	<nav>
+		<span>↳ Reference: <a href="../reference/hoalu-financial-audit.html">Hoalu Financial Audit</a></span>
+		<span>Next: Lesson 2 — The Balance Sheet (assets, liabilities, net worth) →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0002-the-balance-sheet.html
+++ b/finance-lessons/lessons/0002-the-balance-sheet.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 2 — The Balance Sheet</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 2 · Foundations</p>
+	<h1>The Balance Sheet: assets, liabilities, and your real scoreboard</h1>
+	<p class="lesson-meta">Continues <a href="0001-stock-vs-flow.html">Lesson 1</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit §1–2</a></p>
+</header>
+
+<p>Lesson 1 ended with a claim: <em>net worth is the scoreboard; cash flow is the engine.</em> This
+lesson opens the scoreboard. It is the single thing Hoalu most badly lacks.</p>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Asset</dt><dd>Something you <strong>own</strong> that holds value — cash, savings, a paid-off car, a home, investments. Measured at a point in time (a stock).</dd></div>
+	<div class="def-row"><dt>Liability</dt><dd>Something you <strong>owe</strong> — a credit-card balance, a car loan, a mortgage, unpaid taxes. Also a stock.</dd></div>
+	<div class="def-row"><dt>Net worth</dt><dd><strong>Assets − Liabilities</strong>, at a single date. The bottom line of the balance sheet.</dd></div>
+</div>
+
+<h2>A household balance sheet, in one table</h2>
+
+<p>Pick any date — say, <em>tonight</em>. List what you own and what you owe. The rest is arithmetic.</p>
+
+<table>
+	<thead><tr><th>Assets (you own)</th><th>₫</th><th>Liabilities (you owe)</th><th>₫</th></tr></thead>
+	<tbody>
+		<tr><td>Cash &amp; checking</td><td>40,000,000</td><td>Credit-card balance</td><td>15,000,000</td></tr>
+		<tr><td>Savings</td><td>60,000,000</td><td>Car loan</td><td>80,000,000</td></tr>
+		<tr><td>Car (market value)</td><td>200,000,000</td><td>Mortgage</td><td>1,200,000,000</td></tr>
+		<tr><td>Investments</td><td>150,000,000</td><td></td><td></td></tr>
+		<tr><td><strong>Total assets</strong></td><td><strong>450,000,000</strong></td><td><strong>Total liabilities</strong></td><td><strong>1,295,000,000</strong></td></tr>
+	</tbody>
+</table>
+<p style="text-align:center;font-family:var(--sans);font-size:0.9rem"><strong>Net worth = 450,000,000 − 1,295,000,000 = −845,000,000 ₫</strong></p>
+
+<aside class="note">
+	<b>Negative net worth is normal early.</b> A young household with a fresh mortgage almost always
+	owes more than it owns. The goal is not to start positive — it is to make the number rise over
+	years. Track the <em>trend</em>, not the snapshot.
+</aside>
+
+<h2>Why net worth beats income as the scoreboard</h2>
+
+<p>A high earner with high debt and zero savings has a large <em>flow</em> (income) and a
+<em>shrinking</em> stock (net worth). A modest earner who saves consistently has a smaller flow
+but a <em>rising</em> stock. <em>The Millionaire Next Door</em> made this famous: the people who
+actually accumulate wealth are rarely the highest earners — they are the ones whose net worth
+climbs every year because they spend less than they earn and invest the gap.</p>
+
+<p>Income matters only insofar as it feeds the balance sheet. If your income rises but your net
+worth does not, the income is leaking out somewhere. The balance sheet is the lie detector.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the scoreboard is blank</p>
+	<p>Hoalu cannot produce the table above. Concretely:</p>
+	<ul>
+		<li><strong>No balances on wallets</strong> — there is no <code>balance</code> column, so "Cash &amp; checking" and "Savings" cannot be listed. (<a href="../reference/hoalu-financial-audit.html">Audit §1</a>)</li>
+		<li><strong>No liabilities modelled</strong> — a credit card is just a wallet name; a car loan or mortgage has no home at all. (<a href="../reference/hoalu-financial-audit.html">Audit §2</a>)</li>
+		<li><strong>No net-worth series</strong> — no chart of net worth over time, the one trend that actually matters.</li>
+	</ul>
+	<p>The app tracks the engine (income/expense) but cannot show the scoreboard it is supposed to be
+	driving. That is the headline gap this course will keep returning to.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>Tonight, write your own balance sheet on paper: every account you own and every debt you owe,
+with today's date at the top. Whatever the number — positive, zero, negative — you now have a
+baseline. From here, the only question is whether it rises. That is what a finance app must help
+you see, and what Hoalu must learn to show.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can read a balance sheet."
+	data-msg-retry="Re-read the asset/liability definitions, then retry.">
+	<h3>Balance sheet drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="asset" data-reason="A car you own holds market value — it is an asset (a depreciating one, but still an asset).">
+		<p class="quiz-prompt">Your car, worth 200,000,000 ₫.</p>
+		<div class="quiz-options">
+			<button data-choice="asset">Asset</button>
+			<button data-choice="liability">Liability</button>
+			<button data-choice="neither">Neither (it's a flow)</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="liability" data-reason="Money you owe on a loan is a liability — a stock you must eventually pay down.">
+		<p class="quiz-prompt">The 80,000,000 ₫ you still owe on the car loan.</p>
+		<div class="quiz-options">
+			<button data-choice="asset">Asset</button>
+			<button data-choice="liability">Liability</button>
+			<button data-choice="neither">Neither (it's a flow)</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="neither" data-reason="Salary is income earned over a period — a flow. It does not sit on the balance sheet; it feeds it.">
+		<p class="quiz-prompt">Your monthly salary of 30,000,000 ₫.</p>
+		<div class="quiz-options">
+			<button data-choice="asset">Asset</button>
+			<button data-choice="liability">Liability</button>
+			<button data-choice="neither">Neither (it's a flow)</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="liability" data-reason="A carried credit-card balance is debt you owe — a liability, and usually an expensive one.">
+		<p class="quiz-prompt">The 15,000,000 ₫ credit-card balance you did not pay off last month.</p>
+		<div class="quiz-options">
+			<button data-choice="asset">Asset</button>
+			<button data-choice="liability">Liability</button>
+			<button data-choice="neither">Neither (it's a flow)</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="255000000" data-reason="450,000,000 − 95,000,000 = 255,000,000 ₫. Net worth is always assets minus liabilities.">
+		<p class="quiz-prompt">Assets total 450,000,000 ₫; liabilities total 95,000,000 ₫. Net worth is:</p>
+		<div class="quiz-options">
+			<button data-choice="545000000">545,000,000 ₫</button>
+			<button data-choice="255000000">255,000,000 ₫</button>
+			<button data-choice="355000000">355,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://gauss.wordpress.ncsu.edu/files/2020/08/The-Millionaire-Next-Door.pdf">The Millionaire Next Door</a> — Stanley &amp; Danko.</strong>
+	The book's central finding: net worth, not income, is the true measure of financial position, and
+	wealth accumulators are distinguished by behaviour, not paycheque size. It is the clearest case
+	for why Hoalu must surface net worth above all else.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Should my car count as an asset if it loses value every year?"
+		"Is a mortgage 'good debt'?" "How often should I rebuild the balance sheet?" — ask. The
+		answers steer the next lesson.
+	</div>
+	<nav>
+		<span>← <a href="0001-stock-vs-flow.html">Lesson 1: Stock vs Flow</a></span>
+		<span><a href="0003-accounts-done-right.html">Lesson 3: Accounts done right</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0003-accounts-done-right.html
+++ b/finance-lessons/lessons/0003-accounts-done-right.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 3 — Accounts done right</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 3 · The balance-sheet half</p>
+	<h1>Accounts done right: one wallet is not enough</h1>
+	<p class="lesson-meta">Continues <a href="0002-the-balance-sheet.html">Lesson 2</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit §1–2</a></p>
+</header>
+
+<p>A wallet is not just a name and a currency. Each kind of account has a <em>job</em> in the
+household system, and each carries different financial data. Hoalu currently treats them all as
+interchangeable labels — that is the root of the credit-card and balance problems.</p>
+
+<h2>The five accounts a household actually needs</h2>
+
+<aside class="note">
+	<b>Source.</b> This architecture is Ramit Sethi's "conscious spending" system from
+	<i>I Will Teach You to Be Rich</i> — checking, savings, credit card, investment, and (for debt)
+	a separate payoff target. It is the cleanest practical layout.
+</aside>
+
+<table>
+	<thead><tr><th>Account</th><th>Job</th><th>What it must carry</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Checking</strong></td><td>Daily operating account — paycheque in, bills out.</td><td>Opening balance, current balance</td></tr>
+		<tr><td><strong>Savings</strong></td><td>Reserve &amp; sinking funds — money parked for future use.</td><td>Opening balance, current balance, goal allocations</td></tr>
+		<tr><td><strong>Credit card</strong></td><td>Short-term borrowing, paid off monthly for rewards.</td><td>Credit limit, balance owed, available credit, statement date, due date, APR</td></tr>
+		<tr><td><strong>Investment</strong></td><td>Long-term growth — net-worth engine, not spending money.</td><td>Holdings, current value (net worth only)</td></tr>
+		<tr><td><strong>Loan / mortgage</strong></td><td>Long-term debt to pay down.</td><td>Principal owed, interest rate, term, monthly payment</td></tr>
+	</tbody>
+</table>
+
+<p>Notice the third column: <strong>only checking and savings share the same shape</strong>
+(opening + current balance). A credit card is not "a wallet with a negative balance" — it has a
+limit, a statement cycle, a due date, and an APR that a plain balance cannot represent. A loan
+has an amortisation schedule. An investment account has holdings whose value floats daily. One
+<code>wallet</code> table with a <code>type</code> enum cannot hold all of this, and that is why
+Hoalu's model breaks down at the credit card.</p>
+
+<h2>Opening balance: the number that makes everything reconcile</h2>
+
+<p>Every account that holds money needs an <strong>opening balance</strong> — the amount in it at
+the moment you start tracking. Without it, "current balance" is undefined. With it, the rule is
+simple:</p>
+
+<div class="callout">
+	<p class="callout-title def">The reconciliation identity</p>
+	<p style="text-align:center;font-family:var(--sans);font-size:1rem">
+		<strong>current balance = opening balance + Σ(income) − Σ(expenses) − Σ(transfers out) + Σ(transfers in)</strong>
+	</p>
+	<p style="margin-bottom:0">Every transaction that touches the account must move its balance. If the
+	app has no opening balance, the sum starts at zero and every "balance" you see is fiction. This
+	single missing field is why Hoalu cannot show how much money anyone has.</p>
+</div>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — five types, one shape, no balance</p>
+	<ul>
+		<li><code>wallet.type</code> has the right five labels (cash, bank-account, credit-card, debit-card, digital-account) — but <strong>every type uses the same columns</strong>: name, description, currency, isActive. No balance. No credit limit. No APR. No due date. (<a href="../reference/hoalu-financial-audit.html">Audit §1, §2</a>)</li>
+		<li>The wallet table shows a row <strong>count</strong> where a balance sum should be. (<a href="../reference/hoalu-financial-audit.html">Audit §1</a>)</li>
+		<li>Loans and investment accounts have <strong>no entity at all</strong> — they cannot exist in the app.</li>
+	</ul>
+	<p>The fix is not code; it is a <em>decision</em>: give each account type the financial fields its
+	job requires, and make opening balance non-negotiable on every cash-holding account.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>List your real accounts on paper, one per line, with the column each needs. For each, write the
+opening balance you would enter today. You will immediately see which accounts Hoalu can already
+hold (checking, savings — if it had a balance field) and which it structurally cannot (credit
+card, loan, investment). That map is the spec for the balance-sheet half of the app.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you know what each account must carry."
+	data-msg-retry="Re-read the table of five accounts, then retry.">
+	<h3>Match the account to its job</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="checking" data-reason="Checking is the daily operating account — paycheque in, bills out.">
+		<p class="quiz-prompt">"Where my salary lands and my bills go out from."</p>
+		<div class="quiz-options">
+			<button data-choice="checking">Checking</button>
+			<button data-choice="savings">Savings</button>
+			<button data-choice="credit-card">Credit card</button>
+			<button data-choice="investment">Investment</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="savings" data-reason="Savings parks money for future use and for the emergency reserve.">
+		<p class="quiz-prompt">"Where I park three months of expenses as a reserve."</p>
+		<div class="quiz-options">
+			<button data-choice="checking">Checking</button>
+			<button data-choice="savings">Savings</button>
+			<button data-choice="credit-card">Credit card</button>
+			<button data-choice="investment">Investment</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="investment" data-reason="Investment is the long-term growth engine — money you do not intend to spend soon.">
+		<p class="quiz-prompt">"Money I will not touch for ten years, meant to grow."</p>
+		<div class="quiz-options">
+			<button data-choice="checking">Checking</button>
+			<button data-choice="savings">Savings</button>
+			<button data-choice="credit-card">Credit card</button>
+			<button data-choice="investment">Investment</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="credit-card" data-reason="A credit card needs a limit, statement date, due date, and APR — none of which a plain balance can express.">
+		<p class="quiz-prompt">"Which account CANNOT be modelled by just an opening balance and a running total?"</p>
+		<div class="quiz-options">
+			<button data-choice="checking">Checking</button>
+			<button data-choice="savings">Savings</button>
+			<button data-choice="credit-card">Credit card</button>
+			<button data-choice="investment">Investment</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="opening-balance" data-reason="Without an opening balance, current balance = sum from zero = fiction. The opening balance is what makes reconciliation possible.">
+		<p class="quiz-prompt">"The single missing field that makes Hoalu unable to show any balance."</p>
+		<div class="quiz-options">
+			<button data-choice="currency">Currency</button>
+			<button data-choice="opening-balance">Opening balance</button>
+			<button data-choice="color">Color</button>
+			<button data-choice="description">Description</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.iwillteachyoutoberich.com/">I Will Teach You to Be Rich</a> — Ramit Sethi.</strong>
+	The book's first chapters build exactly this account architecture and automate money flow
+	between the five buckets. It is the practical blueprint for what Hoalu's wallet model should
+	grow into.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Do I really need separate checking and savings?" "Is a digital
+		wallet (MoMo, bank app) a checking account or its own type?" "What opening balance do I
+		enter for a credit card?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0002-the-balance-sheet.html">Lesson 2: The Balance Sheet</a></span>
+		<span><a href="0004-credit-cards-as-debt.html">Lesson 4: Credit cards as debt</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0004-credit-cards-as-debt.html
+++ b/finance-lessons/lessons/0004-credit-cards-as-debt.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 4 — Credit cards as debt</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 4 · The balance-sheet half</p>
+	<h1>Credit cards are debt instruments, not wallets</h1>
+	<p class="lesson-meta">Continues <a href="0003-accounts-done-right.html">Lesson 3</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit §2</a></p>
+</header>
+
+<p>A credit card is the one account Hoalu most badly misunderstands. Treated as a wallet, it looks
+like any other container of money. Treated correctly, it is a <strong>revolving loan</strong> with
+a cycle, a grace period, and a punishment for carrying a balance. Get this right and the whole
+"available credit vs balance owed" picture opens up.</p>
+
+<h2>The five numbers a credit card carries</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Credit limit</dt><dd>The most the bank will let you owe at once. A stock — fixed by the bank.</dd></div>
+	<div class="def-row"><dt>Balance owed</dt><dd>What you currently owe. A stock that rises with each purchase and falls with each payment.</dd></div>
+	<div class="def-row"><dt>Available credit</dt><dd><strong>Limit − Balance owed.</strong> How much more you can spend right now.</dd></div>
+	<div class="def-row"><dt>Statement balance</dt><dd>What you owed on the statement closing date. Paying <em>this</em> in full avoids interest.</dd></div>
+	<div class="def-row"><dt>APR</dt><dd>Annual interest rate applied to any balance carried past the due date.</dd></div>
+</div>
+
+<h2>The cycle, and the one rule that makes credit free</h2>
+
+<p>Every card runs a monthly <strong>billing cycle</strong> with two dates that matter:</p>
+
+<table>
+	<thead><tr><th>Date</th><th>What happens</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Statement closing date</strong></td><td>The bank totals your month's purchases → the <em>statement balance</em>.</td></tr>
+		<tr><td><strong>Payment due date</strong></td><td>~25 days later. Pay the <em>statement balance</em> in full by this date → <strong>no interest</strong>.</td></tr>
+	</tbody>
+</table>
+
+<p>The window between those two dates is the <strong>grace period</strong> — the bank's money you
+are using for free. The entire game of "using credit cards well" is: <em>spend on the card for
+rewards and fraud protection, then pay the statement balance in full by the due date, every
+month, forever.</em> Do that and the APR is irrelevant. Slip once and interest charges dating back
+to each purchase erase months of rewards.</p>
+
+<aside class="note">
+	<b>Transactor vs revolnver.</b> A <i>transactor</i> pays in full each month — pays no interest,
+	uses the bank's money free. A <i>revolver</i> carries a balance — pays interest at rates that
+	often exceed 20% APR. The app must show which mode the user is in, because a revolver's credit
+	card is a <strong>liability</strong> on the balance sheet; a transactor's, paid in full, is
+	essentially zero liability.
+</aside>
+
+<h2>Why "available credit" is the number you watch</h2>
+
+<p>For spending decisions, <strong>available credit</strong> (limit − owed) is the live constraint,
+not the limit. A card with a 50,000,000 ₫ limit and 42,000,000 ₫ owed has only 8,000,000 ₫ of
+headroom — and a 84% <em>utilisation</em> that will hurt the user's credit profile. Hoalu must
+show available credit and utilisation, not just "a wallet named Visa."</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the card is an empty label</p>
+	<p><code>wallet.type</code> can be <code>"credit-card"</code>, but the table has <strong>none of the
+	five numbers above</strong> — no limit, no balance owed, no statement date, no due date, no APR.
+	(<a href="../reference/hoalu-financial-audit.html">Audit §2</a>) So the app:</p>
+	<ul>
+		<li>Cannot tell you your available credit before a purchase.</li>
+		<li>Cannot warn you when utilisation is high.</li>
+		<li>Cannot show the card as a <strong>liability</strong> on the balance sheet (Lesson 2).</li>
+		<li>Cannot model the grace period or flag a balance being carried (the expensive case).</li>
+	</ul>
+	<p>A credit card in Hoalu today is a name with a currency and an emoji. Financially it carries no
+	information at all.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>For each card you hold, write down today: limit, balance owed, available credit, statement
+date, due date, APR. Then mark whether you pay in full (transactor) or carry a balance (revolver).
+That single page is what Hoalu must eventually reproduce per card — and it is also the page that
+tells you, right now, whether your cards are free money or expensive debt.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can read a credit card as a debt instrument."
+	data-msg-retry="Re-read the five numbers and the grace period, then retry.">
+	<h3>Credit-card drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="8000000" data-reason="Available credit = limit − balance owed = 50,000,000 − 42,000,000 = 8,000,000 ₫.">
+		<p class="quiz-prompt">Limit 50,000,000 ₫, balance owed 42,000,000 ₫. Available credit is:</p>
+		<div class="quiz-options">
+			<button data-choice="50000000">50,000,000 ₫</button>
+			<button data-choice="8000000">8,000,000 ₫</button>
+			<button data-choice="42000000">42,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="statement-balance" data-reason="Paying the statement balance in full by the due date is what triggers the grace period and avoids all interest.">
+		<p class="quiz-prompt">To pay no interest, you must pay ____ in full by the due date.</p>
+		<div class="quiz-options">
+			<button data-choice="minimum-payment">the minimum payment</button>
+			<button data-choice="statement-balance">the statement balance</button>
+			<button data-choice="credit-limit">the credit limit</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="liability" data-reason="A carried balance is money owed — a liability on the balance sheet, and an expensive one.">
+		<p class="quiz-prompt">A credit-card balance you carry past the due date is, on your balance sheet:</p>
+		<div class="quiz-options">
+			<button data-choice="asset">An asset</button>
+			<button data-choice="liability">A liability</button>
+			<button data-choice="neither">Neither — it's a flow</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="false" data-reason="Slip once (carry a balance) and interest is charged back to each purchase's date — erasing months of rewards. The grace period only holds if you pay in full every cycle.">
+		<p class="quiz-prompt">True or false: missing one full payment then resuming full payments costs nothing, because the grace period returns.</p>
+		<div class="quiz-options">
+			<button data-choice="true">True</button>
+			<button data-choice="false">False</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="transactor" data-reason="A transactor pays in full each month — the bank's money used free, no interest, the card is effectively zero liability.">
+		<p class="quiz-prompt">Someone who pays the statement balance in full every month is called a:</p>
+		<div class="quiz-options">
+			<button data-choice="revolver">revolver</button>
+			<button data-choice="transactor">transactor</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.khanacademy.org/college-careers-more/personal-finance">Khan Academy — Personal Finance, "Credit" unit.</a></strong>
+	The credit-card and APR lessons there walk through statement balances, grace periods, and the
+	math of revolving interest with worked examples. Use it to confirm the mechanics before you
+	spec the card model for Hoalu.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Is a credit card ever worth keeping if I revolve a balance?"
+		"What utilisation is safe?" "Should Hoalu treat a paid-in-full card as zero liability or
+		show the statement balance anyway?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0003-accounts-done-right.html">Lesson 3: Accounts done right</a></span>
+		<span><a href="0005-cash-flow-and-savings-rate.html">Lesson 5: Cash flow &amp; the savings rate</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0005-cash-flow-and-savings-rate.html
+++ b/finance-lessons/lessons/0005-cash-flow-and-savings-rate.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 5 — Cash flow & the savings rate</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 5 · The cash-flow half</p>
+	<h1>Cash flow &amp; the savings rate: the engine, measured</h1>
+	<p class="lesson-meta">Continues <a href="0004-credit-cards-as-debt.html">Lesson 4</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Lesson 2 said the balance sheet is the scoreboard and cash flow is the engine. Hoalu already
+tracks the engine — income and expenses — but never computes the one number that tells you whether
+the engine is actually driving you forward: the <strong>savings rate</strong>.</p>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Cash flow</dt><dd><strong>Income − Expenses</strong> over a period. Positive means you spent less than you earned; negative means you went backwards.</dd></div>
+	<div class="def-row"><dt>Savings</dt><dd>The positive part of cash flow — money left after spending. ("Savings" here means <em>not spent</em>, whether it sits in cash, pays debt, or buys investments.)</dd></div>
+	<div class="def-row"><dt>Savings rate</dt><dd><strong>Savings ÷ Income × 100</strong>, usually over a month or year. The percentage of income you kept.</dd></div>
+</div>
+
+<h2>Why the savings rate is the single most predictive number</h2>
+
+<p>Income alone tells you nothing — a person earning 100,000,000 ₫ and spending 100,000,000 ₫ has
+a 0% savings rate and zero progress. A person earning 30,000,000 ₫ and spending 20,000,000 ₫ has
+a 33% rate and is quietly getting richer every month. <em>The savings rate, not the income, sets
+your trajectory toward financial independence</em> (we will quantify this in Lesson 13). A small
+rate sustained beats a large rate that collapses.</p>
+
+<aside class="note">
+	<b>Savings is broader than "cash in the bank."</b> Money used to pay down a credit-card balance
+	above the minimum, or to buy investments, is savings — it grew your net worth. The rate measures
+	<i>money not consumed</i>, wherever it lands.
+</aside>
+
+<h2>A worked month</h2>
+
+<table>
+	<thead><tr><th>Item</th><th>₫</th></tr></thead>
+	<tbody>
+		<tr><td>Salary (income)</td><td>30,000,000</td></tr>
+		<tr><td>Side income</td><td>4,000,000</td></tr>
+		<tr><td><strong>Total income</strong></td><td><strong>34,000,000</strong></td></tr>
+		<tr><td>Total expenses</td><td>25,000,000</td></tr>
+		<tr><td><strong>Savings (cash flow)</strong></td><td><strong>9,000,000</strong></td></tr>
+	</tbody>
+</table>
+<p style="text-align:center;font-family:var(--sans)"><strong>Savings rate = 9,000,000 ÷ 34,000,000 × 100 ≈ 26%</strong></p>
+
+<p>A 26% rate is solid. A commonly cited healthy target is 20%+; financial-independence seekers
+aim for 50% and above. The number itself is less important than that it is <em>measured, every
+month, and trending up</em>.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the engine is tracked, the output is not</p>
+	<p>Hoalu records income and expenses (the inputs) and even shows period-over-period % on the
+	dashboard — but it <strong>never computes savings or the savings rate</strong>. The dashboard's
+	three stat cards are Incomes / Expenses / Transactions; the missing card is <em>Savings</em>.
+	(<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>)</p>
+	<p>This is the cheapest, highest-value addition to the app: one subtraction (income − expense)
+	and one division (÷ income) surface the number that predicts everything else. No new tables, no
+	new entities — just arithmetic on data Hoalu already has.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>For last month, total your income and your expenses (Hoalu already holds both). Compute the
+savings rate. Write it down. Next month, do it again. The trend of that single percentage is the
+truest measure of whether your household's money management is improving — far more honest than
+the income number alone.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can read a savings rate."
+	data-msg-retry="Re-read the definitions, then retry.">
+	<h3>Savings-rate drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="9000000" data-reason="Cash flow = income − expenses = 34,000,000 − 25,000,000 = 9,000,000 ₫.">
+		<p class="quiz-prompt">Income 34,000,000 ₫, expenses 25,000,000 ₫. Savings (cash flow) is:</p>
+		<div class="quiz-options">
+			<button data-choice="59000000">59,000,000 ₫</button>
+			<button data-choice="9000000">9,000,000 ₫</button>
+			<button data-choice="25000000">25,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="26" data-reason="9,000,000 ÷ 34,000,000 × 100 ≈ 26%. Savings rate is always savings divided by income.">
+		<p class="quiz-prompt">Income 34,000,000 ₫, savings 9,000,000 ₫. Savings rate ≈</p>
+		<div class="quiz-options">
+			<button data-choice="26">26%</button>
+			<button data-choice="34">34%</button>
+			<button data-choice="9">9%</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="zero" data-reason="Spend all you earn and savings = 0, rate = 0%. Income means nothing if it is all consumed; 0% means zero progress.">
+		<p class="quiz-prompt">Earn 100,000,000 ₫, spend 100,000,000 ₫. Savings rate and progress:</p>
+		<div class="quiz-options">
+			<button data-choice="high">High — the income is large</button>
+			<button data-choice="zero">Zero — no progress at all</button>
+			<button data-choice="negative">Negative — debt grew</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="yes" data-reason="Paying down debt above the minimum, or buying investments, both grow net worth — they are savings (money not consumed), wherever it lands.">
+		<p class="quiz-prompt">True or false: money used to pay down a credit-card balance above the minimum counts as savings.</p>
+		<div class="quiz-options">
+			<button data-choice="yes">True</button>
+			<button data-choice="no">False</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="20" data-reason="A commonly cited healthy floor is 20%+; FI seekers aim for 50%+. The exact target matters less than that it is measured and trending up.">
+		<p class="quiz-prompt">A commonly cited healthy minimum savings rate is around:</p>
+		<div class="quiz-options">
+			<button data-choice="5">5%</button>
+			<button data-choice="20">20%</button>
+			<button data-choice="80">80%</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.penguinrandomhouse.com/books/175401/your-money-or-your-life-by-vicki-robin-and-joe-dominguez/">Your Money or Your Life</a> — Robin &amp; Dominguez.</strong>
+	The whole method tracks income and expenses to compute the savings rate, then watches the rate
+	drive net worth toward the "crossover point" — the moment passive income exceeds expenses. It is
+	the clearest argument for making savings rate the dashboard's headline number.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Should the savings rate use gross or net income?" "What counts as
+		'savings' — paying the mortgage principal?" "My rate is negative — what do I fix first?"
+		— ask.
+	</div>
+	<nav>
+		<span>← <a href="0004-credit-cards-as-debt.html">Lesson 4: Credit cards as debt</a></span>
+		<span><a href="0006-transfers.html">Lesson 6: Transfers</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0006-transfers.html
+++ b/finance-lessons/lessons/0006-transfers.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 6 — Transfers</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 6 · The cash-flow half</p>
+	<h1>Transfers are neither income nor expense</h1>
+	<p class="lesson-meta">Continues <a href="0005-cash-flow-and-savings-rate.html">Lesson 5</a> · ~7 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Once a household has more than one account, money starts to <em>move</em> between them —
+paycheque into checking, top up savings, pay the credit-card bill. None of these movements is
+income or expense. Misclassify them and both your cash flow <em>and</em> your balances go wrong at
+once.</p>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Transfer</dt><dd>Moving money from one account you own to another. It changes <strong>where</strong> money sits, not <strong>how much</strong> you have. It touches no income or expense category and never appears on the cash-flow statement.</dd></div>
+</div>
+
+<h2>The rule, and why it matters</h2>
+
+<p>A transfer is a pair of equal-and-opposite balance movements: −X from the source account,
++X to the destination. Your total cash position is unchanged; your net worth is unchanged; your
+income and expense for the month are unchanged. The only thing that moved is the distribution of
+your money across accounts.</p>
+
+<table>
+	<thead><tr><th>Event</th><th>Cash flow?</th><th>Net worth?</th><th>Right type</th></tr></thead>
+	<tbody>
+		<tr><td>Salary arrives in checking</td><td>+ income</td><td>up</td><td>Income</td></tr>
+		<tr><td>Buy groceries on the card</td><td>− expense</td><td>down</td><td>Expense</td></tr>
+		<tr><td>Move 5,000,000 ₫ checking → savings</td><td>unchanged</td><td>unchanged</td><td><strong>Transfer</strong></td></tr>
+		<tr><td>Pay the credit-card bill from checking</td><td>unchanged</td><td>unchanged</td><td><strong>Transfer</strong></td></tr>
+	</tbody>
+</table>
+
+<aside class="note">
+	<b>Why paying the card is a transfer.</b> The expense already happened when you <i>bought</i> the
+	groceries (the card balance rose). Paying the bill just moves cash to clear the debt — one asset
+	down, one liability down by the same amount. Net worth was already reduced at purchase time.
+</aside>
+
+<h2>What goes wrong without a transfer type</h2>
+
+<p>If an app has no transfer concept, users fake it — and every fake corrupts the numbers:</p>
+<ul>
+	<li><strong>As an expense</strong> — moving money to savings looks like "spending," so the savings rate is understated and the user thinks they are poorer than they are.</li>
+	<li><strong>As income</strong> — money arriving in savings looks like earnings, so income is overstated and the savings rate is fictitiously high.</li>
+	<li><strong>Not recorded at all</strong> — then balances cannot reconcile, because the money clearly left one account and arrived in another with no transaction linking them.</li>
+</ul>
+<p>All three are common in apps that lack transfers. The damage is silent: the dashboard shows
+plausible-looking numbers that are all wrong.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — no transfer entity exists</p>
+	<p>Hoalu has income and expense and nothing else. (<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>) Concretely:</p>
+	<ul>
+		<li>There is no way to move money from checking to savings without miscategorising it as expense or income.</li>
+		<li>Paying a credit-card bill cannot be modelled at all — and since the card has no balance owed (Lesson 4), there is nothing to clear anyway.</li>
+		<li>Without transfers, the reconciliation identity from Lesson 3 (<em>balance = opening + income − expenses − transfers out + transfers in</em>) cannot hold — so even if balances existed, they could not be trusted.</li>
+	</ul>
+	<p>Transfers are the connective tissue that lets the balance sheet and the cash-flow statement
+	agree. Hoalu needs them as a first-class transaction type, not a hack.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>List every regular movement of money between your own accounts — paycheque to checking,
+checking to savings, checking to card. For each, confirm: this changes <em>where</em> money sits,
+not <em>whether</em> I'm richer. That mental test — "did my net worth change?" — is exactly how to
+tell a transfer from a real income or expense, for the rest of your life.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can tell a transfer from a real transaction."
+	data-msg-retry="The test is: did net worth change? Re-read, then retry.">
+	<h3>Transfer, expense, or income?</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="transfer" data-reason="Moving cash to savings changes where money sits, not how much you have — net worth unchanged. Transfer.">
+		<p class="quiz-prompt">Move 5,000,000 ₫ from checking to savings.</p>
+		<div class="quiz-options">
+			<button data-choice="income">Income</button>
+			<button data-choice="expense">Expense</button>
+			<button data-choice="transfer">Transfer</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="expense" data-reason="Buying groceries reduces net worth — you traded money for goods you consume. Expense.">
+		<p class="quiz-prompt">Buy 800,000 ₫ of groceries on the credit card.</p>
+		<div class="quiz-options">
+			<button data-choice="income">Income</button>
+			<button data-choice="expense">Expense</button>
+			<button data-choice="transfer">Transfer</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="transfer" data-reason="Paying the card bill moves cash to clear debt — asset down, liability down, net worth unchanged. The expense already happened at purchase. Transfer.">
+		<p class="quiz-prompt">Pay the 12,000,000 ₫ credit-card bill from checking.</p>
+		<div class="quiz-options">
+			<button data-choice="income">Income</button>
+			<button data-choice="expense">Expense</button>
+			<button data-choice="transfer">Transfer</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="income" data-reason="A salary arriving from outside increases net worth — it is income, not a transfer (the source is not your own account).">
+		<p class="quiz-prompt">Salary of 30,000,000 ₫ arrives in checking from your employer.</p>
+		<div class="quiz-options">
+			<button data-choice="income">Income</button>
+			<button data-choice="expense">Expense</button>
+			<button data-choice="transfer">Transfer</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="understated" data-reason="Recording a transfer-to-savings as an expense makes spending look higher than it is, so savings rate is understated — you look poorer than you are.">
+		<p class="quiz-prompt">If a transfer to savings is wrongly logged as an expense, the savings rate is:</p>
+		<div class="quiz-options">
+			<button data-choice="overstated">overstated</button>
+			<button data-choice="understated">understated</button>
+			<button data-choice="unaffected">unaffected</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.youneedabudget.com/method/">The YNAB Method.</a></strong>
+	YNAB treats transfers between on-budget accounts as non-transactions for category purposes —
+	exactly the rule in this lesson. Reading their explanation solidifies why moving your own money
+	must never touch the cash-flow statement.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Is paying the mortgage a transfer or an expense?" "What about
+		moving money to an investment account?" "Should transfers between family members' accounts
+		count?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0005-cash-flow-and-savings-rate.html">Lesson 5: Savings rate</a></span>
+		<span><a href="0007-budgeting-systems.html">Lesson 7: Budgeting systems</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0007-budgeting-systems.html
+++ b/finance-lessons/lessons/0007-budgeting-systems.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 7 — Budgeting systems</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 7 · Planning</p>
+	<h1>Budgeting systems: a plan, not just a record</h1>
+	<p class="lesson-meta">Continues <a href="0006-transfers.html">Lesson 6</a> · ~9 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Hoalu records what you spent. A budget decides what you <em>will</em> spend — before you spend
+it. The difference is the difference between a rear-view mirror and a steering wheel. A finance
+app without budgets can only describe the past; it cannot help you drive the future.</p>
+
+<h2>Three systems, one choice</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>50/30/20</dt><dd>A simple <strong>proportion</strong> rule: ~50% needs, ~30% wants, ~20% savings/debt. Easiest to start; coarsest in control.</dd></div>
+	<div class="def-row"><dt>Zero-based (envelope)</dt><dd><strong>Give every unit of income a job before you spend it.</strong> Allocate all income into envelopes (categories + savings) so income − allocations = 0. Tightest control; most work.</dd></div>
+	<div class="def-row"><dt>Category budgets</dt><dd>Set a <strong>monthly cap per category</strong> (Food 6,000,000 ₫, Transport 2,000,000 ₫…) and track actual vs cap. The middle ground most apps use.</dd></div>
+</div>
+
+<table>
+	<thead><tr><th>System</th><th>Effort</th><th>Control</th><th>Best for</th></tr></thead>
+	<tbody>
+		<tr><td>50/30/20</td><td>Low</td><td>Low</td><td>Beginners, stable income, no debt trouble</td></tr>
+		<tr><td>Category budgets</td><td>Medium</td><td>Medium</td><td>Most households — flexibility with guardrails</td></tr>
+		<tr><td>Zero-based</td><td>High</td><td>High</td><td>Tight cash flow, debt payoff, variable income</td></tr>
+	</tbody>
+</table>
+
+<aside class="note">
+	<b>The core idea they share.</b> Every system is a <i>plan</i> (a cap or allocation) compared
+	against an <i>actual</i>. The budget is the plan; the expenses are the actual. Without the plan,
+	you only have the actual — which is what Hoalu has today.
+</aside>
+
+<h2>The number a budget lives or dies on: budget vs actual</h2>
+
+<p>The whole point of a budget is the comparison. For each category, each month:</p>
+
+<p style="text-align:center;font-family:var(--sans);font-size:1rem"><strong>remaining = budget cap − spent so far</strong></p>
+
+<p>That "remaining" is the steering wheel. Mid-month, Food has 1,500,000 ₫ left against a
+6,000,000 ₫ cap? You can pace yourself. Already at 5,800,000 ₫ by the 10th? Pull back. Without
+the cap, you only learn you overspent <em>after</em> the month closes — too late to steer.</p>
+
+<h2>Rollover: why a month is not an island</h2>
+
+<p>Real spending is lumpy. You buy a year of insurance in March; you skip groceries in April while
+travelling. A rigid monthly cap punishes the lump; a <strong>rollover</strong> lets underspend
+carry forward as next month's buffer, and overspend carry forward as a debt against next month's
+cap. Rollover is what makes category budgets survive real life — and it is also exactly the
+mechanic behind <strong>sinking funds</strong> (Lesson 10).</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — only event budgets exist</p>
+	<ul>
+		<li>The only <code>budget</code> field in the entire schema is on <code>event</code> — a per-event cap, not a recurring monthly cap per category. (<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>)</li>
+		<li>There is <strong>no budget-vs-actual reporting</strong> outside events — no "Food: 4,200,000 of 6,000,000" card.</li>
+		<li>No rollover, no envelopes, no allocation. The 50/30/20 and zero-based systems cannot be expressed at all.</li>
+	</ul>
+	<p>The smallest useful version: a <code>budget</code> per (workspace, category, month) with a
+	cap and a spent-so-far rollup — then a dashboard card of remaining per category. That alone
+	turns Hoalu from a record into a plan.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>Pick a system for your household this month — start with 50/30/20 if you've never budgeted,
+category budgets if you want control. Write one cap per category on paper before the month begins.
+At the end, compare actual to cap. The gap between plan and reality is where every useful
+financial insight lives — and it is the gap Hoalu must learn to show.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you know a plan from a record."
+	data-msg-retry="Re-read the three systems and the budget-vs-actual idea, then retry.">
+	<h3>Budgeting drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="zero-based" data-reason="Zero-based gives every unit of income a job before spending, so income − allocations = 0. It is the tightest control.">
+		<p class="quiz-prompt">"Give every dong a job before you spend it" describes which system?</p>
+		<div class="quiz-options">
+			<button data-choice="50-30-20">50/30/20</button>
+			<button data-choice="category">Category budgets</button>
+			<button data-choice="zero-based">Zero-based</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="remaining" data-reason="The live number to steer by is remaining = cap − spent so far. It tells you whether to ease off or keep going, mid-month.">
+		<p class="quiz-prompt">The number that actually lets you steer mid-month is:</p>
+		<div class="quiz-options">
+			<button data-choice="total-spent">total spent this month</button>
+			<button data-choice="remaining">remaining (cap − spent)</button>
+			<button data-choice="last-month">last month's total</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="record" data-reason="Without caps or allocations, the app only has actuals — a record of the past, not a plan for the future.">
+		<p class="quiz-prompt">An app that tracks expenses but sets no caps is a ____, not a budget.</p>
+		<div class="quiz-options">
+			<button data-choice="plan">plan</button>
+			<button data-choice="record">record</button>
+			<button data-choice="forecast">forecast</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="rollover" data-reason="Rollover lets underspend carry forward as buffer and overspend as debt against next month's cap — it is what makes budgets survive lumpy real spending.">
+		<p class="quiz-prompt">Underspend in March carrying forward as April's buffer is called:</p>
+		<div class="quiz-options">
+			<button data-choice="rollover">rollover</button>
+			<button data-choice="surplus">surplus</button>
+			<button data-choice="refund">refund</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="no-monthly-cap" data-reason="Hoalu's only budget field is on events; there is no recurring monthly cap per category, so budget-vs-actual outside events is impossible.">
+		<p class="quiz-prompt">Why can't Hoalu show "Food: 4.2M of 6M" today?</p>
+		<div class="quiz-options">
+			<button data-choice="no-monthly-cap">no monthly cap per category exists</button>
+			<button data-choice="no-expenses">expenses aren't tracked</button>
+			<button data-choice="no-categories">categories don't exist</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.youneedabudget.com/method/">The YNAB Method (four rules).</a></strong>
+	The clearest statement of zero-based budgeting, including the "roll with the punches" rule that
+	is exactly the rollover mechanic above. Read it even if you choose a different system — the
+	thinking transfers.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Which system fits a variable freelance income?" "Should savings
+		count as a budget category?" "How do I budget for annual expenses like insurance?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0006-transfers.html">Lesson 6: Transfers</a></span>
+		<span><a href="0008-recurring-bills.html">Lesson 8: Recurring bills done right</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0008-recurring-bills.html
+++ b/finance-lessons/lessons/0008-recurring-bills.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 8 — Recurring bills done right</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 8 · Operations</p>
+	<h1>Recurring bills &amp; subscriptions done right</h1>
+	<p class="lesson-meta">Continues <a href="0007-budgeting-systems.html">Lesson 7</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit §9–11</a></p>
+</header>
+
+<p>Recurring bills are the part of Hoalu that already works well — occurrence projection, the
+overdue/today/upcoming view, the "log a payment" link to expenses. This lesson is partly a
+celebration, partly the edge cases the engine gets wrong, and partly the household habit the
+feature should enable: the <strong>subscription audit</strong>.</p>
+
+<h2>The model, done well</h2>
+
+<p>A recurring bill is a <em>definition</em> — an amount, a currency, a frequency, an anchor date,
+and a destination wallet and category. From that definition, the engine <em>projects
+occurrences</em>: each expected payment on its due date, initially unpaid. When the user logs a
+payment, an expense is created and the matching occurrence is marked paid. The bill becomes two
+layers: a stable template and a stream of actual events. That is exactly the right shape, and
+Hoalu has it.</p>
+
+<aside class="note">
+	<b>Why two layers matters.</b> Without occurrences you only know the bill <i>exists</i>; you
+	never know whether <i>this month's</i> instalment was paid. The occurrence layer is what turns a
+	reminder into a trackable obligation — and what lets the upcoming-bills view show paid/unpaid
+	status per instance.
+</aside>
+
+<h2>The household habit: the subscription audit</h2>
+
+<p>Recurring bills are where money leaks silently. A household accumulates streaming, software,
+gym, and app subscriptions that auto-renew forever, each small enough to ignore. The fix is a
+periodic <strong>subscription audit</strong>: list every recurring charge, mark each <em>used</em>
+or <em>not used</em>, and cancel the second kind. The audit pays for itself in an afternoon. An app
+should make this trivial — one screen, total monthly recurring, sorted by amount, with a
+"last used?" nudge. Hoalu's recurring-bills list is 80% of this feature already.</p>
+
+<h2>Three edge cases the engine mishandles</h2>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — where the engine cracks</p>
+	<ul>
+		<li><strong><code>dueDay = 0</code> is accepted but invalid.</strong> The schema allows 0–31. For a monthly bill, day 0 means "last day of the <em>previous</em> month" — occurrences land in the wrong month. The field can't validate because one number serves both weekly (0–6) and monthly (1–31) frequencies. (<a href="../reference/hoalu-financial-audit.html">Audit §9</a>)</li>
+		<li><strong>"One-time" and "custom" recurring bills generate nothing.</strong> A "one-time recurring bill" is a contradiction; the generator has no branch for it and returns empty — silently. The schema permits it. (<a href="../reference/hoalu-financial-audit.html">Audit §10</a>)</li>
+		<li><strong>Income's <code>repeat</code> is decorative.</strong> <code>income.repeat</code> exists but there is no <code>recurringBillId</code> and no occurrence logic — so a salary marked "monthly" never projects. Recurring logic exists only for expenses. (<a href="../reference/hoalu-financial-audit.html">Audit §11</a>)</li>
+	</ul>
+</div>
+
+<h2>The 31st-of-February question</h2>
+
+<p>A bill "due on the 31st" has no due date in February, April, June, etc. Two defensible policies:
+<strong>clamp</strong> (charge on the 28th/30th, never skip) or <strong>skip</strong> (no charge
+that month). Hoalu clamps — which is fine — but should say so to the user, because a bill charged
+on the 28th that the user expects on the 31st is a reconciliation surprise. The bigger lesson:
+<em>every</em> edge case in scheduling should be visible to the user, not silently absorbed.</p>
+
+<div class="callout">
+	<p class="callout-title warn">The general principle</p>
+	<p>Any time a finance engine makes a quiet decision for the user — clamping a date, skipping a
+	month, zeroing a missing amount — that decision must be <strong>surfaced</strong>. Silent
+	behaviour in a money app is a bug, even when the behaviour is reasonable, because the user
+	cannot reconcile what they do not know happened.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>Do a subscription audit tonight. Open Hoalu's recurring-bills list (or write one on paper):
+every recurring charge, its monthly equivalent, and "used / not used this month." Cancel the nots.
+Then sum the monthly total of what remains — that single number is your <em>recurring floor</em>,
+the minimum the household must clear each month before any discretionary spending.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can audit subscriptions and spot the edge cases."
+	data-msg-retry="Re-read the three edge cases, then retry.">
+	<h3>Recurring-bills drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="definition-and-occurrences" data-reason="The definition is the template (amount, frequency); occurrences are the projected instances, each paid or unpaid. Two layers is the right shape.">
+		<p class="quiz-prompt">A well-modelled recurring bill is split into two layers:</p>
+		<div class="quiz-options">
+			<button data-choice="definition-and-occurrences">a definition + projected occurrences</button>
+			<button data-choice="single-record">a single payment record</button>
+			<button data-choice="budget-and-actual">a budget and an actual</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="wrong-month" data-reason="dueDay=0 for a monthly bill resolves to the last day of the previous month — occurrences land in the wrong month. (Audit §9)">
+		<p class="quiz-prompt">A monthly bill with dueDay = 0 produces occurrences on:</p>
+		<div class="quiz-options">
+			<button data-choice="first">the 1st of the month</button>
+			<button data-choice="wrong-month">the last day of the previous month</button>
+			<button data-choice="none">no occurrences at all</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="nothing" data-reason="The generator has branches only for daily/weekly/monthly/yearly. "One-time" and "custom" fall through to empty — a contradiction the schema permits. (Audit §10)">
+		<p class="quiz-prompt">A recurring bill marked "one-time" generates how many occurrences?</p>
+		<div class="quiz-options">
+			<button data-choice="one">exactly one</button>
+			<button data-choice="nothing">nothing (silently)</button>
+			<button data-choice="error">a validation error</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="nothing" data-reason="income.repeat exists but there's no recurringBillId and no occurrence logic — a salary marked "monthly" never projects. Only expenses recur. (Audit §11)">
+		<p class="quiz-prompt">Marking a salary record as "monthly" in Hoalu causes:</p>
+		<div class="quiz-options">
+			<button data-choice="monthly-entries">monthly auto-entries from now on</button>
+			<button data-choice="nothing">nothing — the field is decorative</button>
+			<button data-choice="reminder">a monthly reminder</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="surfaced" data-reason="Silent behaviour in a money app is a bug — every quiet decision (clamping, skipping, zeroing) must be surfaced so the user can reconcile.">
+		<p class="quiz-prompt">When the engine clamps a 31st-of-Feb bill to the 28th, the decision should be:</p>
+		<div class="quiz-options">
+			<button data-choice="silent">silent — the user need not know</button>
+			<button data-choice="surfaced">surfaced — the user must be told</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.iwillteachyoutoberich.com/">I Will Teach You to Be Rich</a> — Ramit Sethi, the "conscious spending" chapters.</strong>
+	Sethi frames subscriptions and recurring bills as the "fixed costs" you automate first, then
+	consciously cap — the exact habit the subscription audit enables. Read it to ground the
+	household practice around Hoalu's strongest feature.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Should a mortgage be a recurring bill or a loan?" "How do I model a
+		bill that rises with inflation each year?" "Annual vs monthly — which should the app show by
+		default?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0007-budgeting-systems.html">Lesson 7: Budgeting systems</a></span>
+		<span><a href="0009-multi-currency.html">Lesson 9: Multi-currency done right</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0009-multi-currency.html
+++ b/finance-lessons/lessons/0009-multi-currency.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 9 — Multi-currency done right</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 9 · Operations</p>
+	<h1>Multi-currency done right: rate at the transaction date</h1>
+	<p class="lesson-meta">Continues <a href="0008-recurring-bills.html">Lesson 8</a> · ~9 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit §5–8, §12</a></p>
+</header>
+
+<p>Your family may earn in one currency and spend in another. That makes the app's job genuinely
+hard — and Hoalu's FX pipeline is where the most <em>silent data corruption</em> lives. Every
+defect here quietly misstates your totals, with no warning.</p>
+
+<h2>The one principle</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Rate-at-transaction-date</dt><dd>Convert a foreign amount using the exchange rate that was valid on the <strong>transaction's own date</strong> — never the date you entered it, and never a single rate for a whole month.</dd></div>
+	<div class="def-row"><dt>Reporting currency</dt><dd>The single currency in which all totals are expressed for comparison. Should be a <em>user setting</em>, not a heuristic.</dd></div>
+</div>
+
+<p>Why the transaction date? An expense on 1 March and one on 31 March can sit at very different
+rates, especially for volatile currencies. A single month-end rate makes the 1st look as if it
+happened at month-end prices — a small lie per transaction, a large lie in the sum. The transaction
+date is the only honest anchor.</p>
+
+<h2>What can go wrong, and how Hoalu fails each</h2>
+
+<table>
+	<thead><tr><th>Defect</th><th>What happens</th><th>Honest fix</th></tr></thead>
+	<tbody>
+		<tr><td>Single rate for whole month <span class="tag" style="font-family:var(--sans);font-size:0.65rem">Audit §5</span></td><td>All March txns use the 31-Mar rate</td><td>Convert each txn at its own date</td></tr>
+		<tr><td><code>created_at</code> not <code>date</code> <span class="tag" style="font-family:var(--sans);font-size:0.65rem">Audit §6</span></td><td>Backdated expense uses the entry-day rate</td><td>Look up by <code>date</code>, not <code>created_at</code></td></tr>
+		<tr><td>Missing rate → zero <span class="tag" style="font-family:var(--sans);font-size:0.65rem">Audit §7</span></td><td>No rate found → amount contributes 0 (frontend) or is skipped (backend)</td><td>Flag it loudly, never silently drop</td></tr>
+		<tr><td>Primary currency by count <span class="tag" style="font-family:var(--sans);font-size:0.65rem">Audit §8</span></td><td>100 tiny USD txns beat 50 large VND ones</td><td>Use the workspace setting, not a count heuristic</td></tr>
+		<tr><td>Float cross-rate maths <span class="tag" style="font-family:var(--sans);font-size:0.65rem">Audit §12</span></td><td><code>parseFloat</code> drift in X→USD→Y</td><td>Use decimal/integer minor-units</td></tr>
+	</tbody>
+</table>
+
+<aside class="note">
+	<b>Cross-rates.</b> To convert VND→EUR you usually go VND→USD→EUR because direct VND/EUR rates
+	are rare. Each hop must use the rate valid on the <i>transaction date</i>. Hoalu's cross-rate is
+	right in shape; it just loses precision by doing it in floating point and at the wrong date.
+</aside>
+
+<h2>The cardinal sin: silent zeroing</h2>
+
+<p>Of all the FX defects, the worst is <strong>silently dropping an amount when no rate is
+found</strong>. A user with a USD expense in a VND workspace, no rate loaded, sees that expense
+contribute <em>nothing</em> to every total — with no warning. Their monthly spend looks lower than
+it is; their savings rate looks higher; their budget looks under. They make decisions on numbers
+that are quietly, invisibly wrong.</p>
+
+<div class="callout">
+	<p class="callout-title warn">Principle</p>
+	<p>A missing rate is a <strong>data problem the user must be told about</strong>, not a reason
+	to set the amount to zero. Surface it: "3 expenses can't be totalled — update the USD→VND rate
+	for these dates." Never let a missing input silently corrupt an output.</p>
+</div>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — five defects, one pipeline</p>
+	<p>The FX pipeline is a single chain, so each defect compounds: a backdated March expense with no
+	rate, summed at month-end in float, in a workspace whose reporting currency was guessed by
+	count — that one expense is wrong five ways at once, and the dashboard shows a confident-looking
+	total that is fiction. (<a href="../reference/hoalu-financial-audit.html">Audit §5–8, §12</a>)</p>
+	<p>The fix is a decision, not a refactor: <strong>one principle (rate at txn date), one setting
+	(reporting currency), one rule (missing rate = visible error)</strong>. Apply those three and
+	the pipeline becomes honest.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>If your household uses more than one currency, write down which. Choose your reporting currency
+(the one you think in). For your last foreign expense, find the exchange rate on the actual
+transaction date — not today's. The discipline of "what was the rate on the day it happened?" is
+the whole habit; the app should enforce it, not you.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can spot every FX trap."
+	data-msg-retry="Re-read the one principle and the five defects, then retry.">
+	<h3>Multi-currency drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="transaction-date" data-reason="Each transaction converts at the rate valid on its own date — never the entry date, never a single month rate. That is the one principle.">
+		<p class="quiz-prompt">Which date should an expense's exchange rate come from?</p>
+		<div class="quiz-options">
+			<button data-choice="entry-date">the date you entered it</button>
+			<button data-choice="month-end">the last day of its month</button>
+			<button data-choice="transaction-date">the transaction's own date</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="zero" data-reason="No rate → multiplier 0 (frontend) or row skipped (backend). The amount silently contributes nothing to totals. (Audit §7)">
+		<p class="quiz-prompt">When Hoalu can't find an FX rate for an expense, the amount contributes ____ to totals.</p>
+		<div class="quiz-options">
+			<button data-choice="zero">zero (silently)</button>
+			<button data-choice="original">its original value</button>
+			<button data-choice="average">the period average</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="entry-date" data-reason="Hoalu looks up FX by created_at (the insert timestamp), so a backdated expense gets the entry-day rate, not the transaction-day rate. (Audit §6)">
+		<p class="quiz-prompt">A backdated expense uses the rate from which date in Hoalu today?</p>
+		<div class="quiz-options">
+			<button data-choice="entry-date">the date it was entered</button>
+			<button data-choice="transaction-date">the transaction's own date</button>
+			<button data-choice="month-end">month-end</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="setting" data-reason="The reporting currency should be a user/workspace setting (which Hoalu already stores) — not guessed by counting expense rows. (Audit §8)">
+		<p class="quiz-prompt">How should the app pick the currency all totals are shown in?</p>
+		<div class="quiz-options">
+			<button data-choice="count">the currency with the most expense rows</button>
+			<button data-choice="setting">an explicit user setting</button>
+			<button data-choice="latest">the most recently used currency</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="visible-error" data-reason="A missing rate is a data problem to surface, never a reason to silently zero the amount. The user must be told to fix it.">
+		<p class="quiz-prompt">The honest response to a missing exchange rate is:</p>
+		<div class="quiz-options">
+			<button data-choice="zero">set the amount to zero</button>
+			<button data-choice="visible-error">a visible error asking the user to add the rate</button>
+			<button data-choice="skip">silently skip the row</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.investopedia.com/terms/c/currency-risk.asp">Investopedia — Currency (FX) Risk.</a></strong>
+	The household-scale version of what treasuries manage: exchange-rate movements change the real
+	value of money you hold across currencies. Use it to understand why the rate's <em>date</em>
+	matters — and why a multi-currency family is taking real risk the app must represent honestly.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Should I hold savings in USD or VND?" "What reporting currency
+		should a mixed household use?" "How often should the app fetch fresh rates?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0008-recurring-bills.html">Lesson 8: Recurring bills</a></span>
+		<span><a href="0010-sinking-funds.html">Lesson 10: Sinking funds</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0010-sinking-funds.html
+++ b/finance-lessons/lessons/0010-sinking-funds.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 10 — Sinking funds</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 10 · Planning</p>
+	<h1>Savings goals &amp; sinking funds: give the future a place to live</h1>
+	<p class="lesson-meta">Continues <a href="0009-multi-currency.html">Lesson 9</a> · ~8 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Some expenses are large, known, and months away — annual insurance, a tax bill, a trip home, a
+new phone. The mistake is to treat them as <em>surprises</em> when they arrive. A <strong>sinking
+fund</strong> turns a future lump into many small present contributions. It is budgeting across
+time, not just across categories.</p>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Sinking fund</dt><dd>Money set aside gradually for a <strong>known future expense</strong> of a known amount and date. Each month you sink a little in, so the lump never hits cash flow all at once.</dd></div>
+	<div class="def-row"><dt>Monthly contribution</dt><dd><strong>Target amount ÷ months remaining</strong>. The amount to save each month so the fund hits its target by the due date.</dd></div>
+	<div class="def-row"><dt>Envelope</dt><dd>An allocation of money to a purpose <em>within</em> a single savings account — the fund exists as a labelled slice, not a separate bank account.</dd></div>
+</div>
+
+<h2>The arithmetic</h2>
+
+<p style="text-align:center;font-family:var(--sans);font-size:1rem"><strong>monthly contribution = target amount ÷ months remaining</strong></p>
+
+<p>Annual insurance of 12,000,000 ₫ due in 12 months → 1,000,000 ₫/month. A trip of 30,000,000 ₫
+in 10 months → 3,000,000 ₫/month. The lumpy future becomes a smooth, budgetable present line —
+exactly like a recurring bill, but where you pay <em>yourself</em> first.</p>
+
+<aside class="note">
+	<b>The reconciliation test.</b> A sinking fund changes <em>where</em> money is allocated, not
+	<em>whether</em> you have it. Moving cash into the fund is a <strong>transfer</strong>
+	(Lesson 6), not an expense — your net worth is unchanged. The expense is recorded later, when
+	the purchase happens, paid <i>from</i> the fund.
+</aside>
+
+<h2>Why this is different from "saving"</h2>
+
+<p>Generic savings protects against the unknown. A sinking fund is the opposite — it is for a
+<em>specific</em> future expense you can name and date. The household difference is huge: without
+sinking funds, known future lumps masquerade as emergencies when they arrive, and the emergency
+fund gets drained by things that were never emergencies. With sinking funds, the emergency fund
+stays reserved for the genuinely unexpected.</p>
+
+<table>
+	<thead><tr><th></th><th>Emergency fund</th><th>Sinking fund</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Purpose</strong></td><td>Unknown bad event</td><td>Known future expense</td></tr>
+		<tr><td><strong>Amount</strong></td><td>3–6 months of expenses</td><td>Exact target</td></tr>
+		<tr><td><strong>Timing</strong></td><td>Indefinite</td><td>Known due date</td></tr>
+		<tr><td><strong>Withdrawal</strong></td><td>When disaster strikes</td><td>On the planned date</td></tr>
+	</tbody>
+</table>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the future has no address</p>
+	<ul>
+		<li>There is <strong>no goal or allocation entity</strong> — money in a savings account is an undifferentiated balance, with no label saying "this 6,000,000 is for insurance." (<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>)</li>
+		<li>Without allocations, the app cannot compute "monthly contribution to keep on track," cannot warn when a fund is behind, and cannot show a due-date countdown.</li>
+		<li>This compounds with the missing <strong>transfer</strong> (Lesson 6) and missing <strong>per-category budget</strong> (Lesson 7): sinking funds need both to exist as a first-class concept.</li>
+	</ul>
+	<p>The smallest useful version: a <code>goal</code> with target amount, target date, linked
+	wallet, and a rollup of allocated transfers — then a card per goal showing "on track / behind by
+	X months." That is the feature that turns a savings account from a pile into a plan.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>List every known future expense in the next 12 months — insurance, tax, travel, a replacement
+phone, school fees. For each, write the amount and the month it's due. Divide amount by months
+remaining. The list of monthly contributions is a new set of "bills you owe yourself" — and it
+almost always reveals you are under-saving for something specific.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can plan a sinking fund."
+	data-msg-retry="Re-read the contribution formula and the emergency-vs-sinking split, then retry.">
+	<h3>Sinking-fund drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="1000000" data-reason="12,000,000 ÷ 12 = 1,000,000 ₫/month. Target ÷ months remaining.">
+		<p class="quiz-prompt">Insurance of 12,000,000 ₫ due in 12 months. Monthly contribution:</p>
+		<div class="quiz-options">
+			<button data-choice="12000000">12,000,000 ₫</button>
+			<button data-choice="1000000">1,000,000 ₫</button>
+			<button data-choice="6000000">6,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="3000000" data-reason="30,000,000 ÷ 10 = 3,000,000 ₫/month.">
+		<p class="quiz-prompt">A trip of 30,000,000 ₫ in 10 months. Monthly contribution:</p>
+		<div class="quiz-options">
+			<button data-choice="3000000">3,000,000 ₫</button>
+			<button data-choice="30000000">30,000,000 ₫</button>
+			<button data-choice="1000000">1,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="transfer" data-reason="Moving cash into the fund changes where money is allocated, not whether you have it — net worth unchanged. It is a transfer (Lesson 6), not an expense.">
+		<p class="quiz-prompt">Putting money into a sinking fund is, on the cash-flow statement:</p>
+		<div class="quiz-options">
+			<button data-choice="expense">an expense</button>
+			<button data-choice="income">income</button>
+			<button data-choice="transfer">a transfer (no effect)</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="sinking" data-reason="A sinking fund is for a known future expense of known amount and date — the opposite of the emergency fund, which is for unknown events.">
+		<p class="quiz-prompt">Money set aside for annual insurance is a ____ fund.</p>
+		<div class="quiz-options">
+			<button data-choice="emergency">emergency</button>
+			<button data-choice="sinking">sinking</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="emergency" data-reason="The emergency fund should stay reserved for the genuinely unexpected; without sinking funds, known lumps drain it and real emergencies go uncovered.">
+		<p class="quiz-prompt">Without sinking funds, known future lumps drain the ____ fund by mistake.</p>
+		<div class="quiz-options">
+			<button data-choice="emergency">emergency</button>
+			<button data-choice="sinking">sinking</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.youneedabudget.com/method/">The YNAB Method — Rule 2: "Embrace your true expenses."</a></strong>
+	YNAB's second rule is sinking funds under another name: take large, less-frequent expenses and
+	treat them as monthly. The clearest practical framing of this lesson's idea.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Should each sinking fund be a separate account or one account with
+		labels?" "What if the due date passes and the fund is short?" "Do I earn interest on sinking
+		funds?" — ask.
+	</div>
+	<nav>
+		<span>← <a href="0009-multi-currency.html">Lesson 9: Multi-currency</a></span>
+		<span><a href="0011-debt-and-loans.html">Lesson 11: Debt &amp; loans</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0011-debt-and-loans.html
+++ b/finance-lessons/lessons/0011-debt-and-loans.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 11 — Debt & loans</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 11 · The balance-sheet half</p>
+	<h1>Debt &amp; loans: amortization, and avalanche vs. snowball</h1>
+	<p class="lesson-meta">Continues <a href="0010-sinking-funds.html">Lesson 10</a> · ~9 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Lesson 4 covered the worst debt — revolving credit cards. This lesson covers the rest: loans
+with a principal, an interest rate, and a term. Hoalu has no entity for any of them. Understanding
+amortization and the two payoff strategies is what turns a scary balance into a plan.</p>
+
+<h2>The anatomy of a loan</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Principal</dt><dd>The amount you still owe — the part of the balance that is yours to pay down. A stock.</dd></div>
+	<div class="def-row"><dt>Interest</dt><dd>The cost of borrowing — a flow the lender charges each period on the outstanding principal.</dd></div>
+	<div class="def-row"><dt>Term</dt><dd>The number of payments scheduled to clear the loan.</dd></div>
+	<div class="def-row"><dt>Amortization</dt><dd>The schedule that splits each fixed payment into <strong>interest</strong> (on the remaining principal) and <strong>principal reduction</strong>. Early payments are mostly interest; late payments are mostly principal.</dd></div>
+</div>
+
+<aside class="note">
+	<b>The front-loaded trap.</b> Because interest is charged on the <i>outstanding</i> principal,
+	early payments are almost all interest — you barely dent the principal for years. This is why a
+	30-year mortgage feels stuck for the first decade. Extra payments against principal, early,
+	shorten the loan far more than the same money applied years later.
+</aside>
+
+<h2>The minimum payment is a trap</h2>
+
+<p>Every loan quotes a <strong>minimum payment</strong>. It is sized to stretch the loan across
+the full term — maximising the interest you pay. Paying only the minimum on a credit card is the
+single most expensive habit a household can have: a 20,000,000 ₫ balance at 25% APR, paying the
+~2% minimum, takes <em>decades</em> and costs more in interest than the original purchase. The
+rule: <strong>always pay more than the minimum, against the highest-APR debt first</strong>.</p>
+
+<h2>Two strategies for multiple debts</h2>
+
+<table>
+	<thead><tr><th></th><th>Avalanche</th><th>Snowball</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Order</strong></td><td>Highest <em>APR</em> first</td><td>Smallest <em>balance</em> first</td></tr>
+		<tr><td><strong>Cost</strong></td><td>Mathematically least interest</td><td>Slightly more interest</td></tr>
+		<tr><td><strong>Motivation</strong></td><td>Slower visible wins</td><td>Fast wins as balances hit zero</td></tr>
+		<tr><td><strong>Best for</strong></td><td>Disciplined, pure-maths types</td><td>People who need momentum</td></tr>
+	</tbody>
+</table>
+
+<p>Both work the same way: pay minimums on every debt, then throw <em>all</em> spare cash at the
+target debt until it is gone, then roll that freed-up amount onto the next target. Avalanche is
+cheapest; snowball is most motivating. The best strategy is <em>the one you will actually stick
+to</em> — a plan you abandon saves nothing.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — debt is invisible</p>
+	<ul>
+		<li>There is <strong>no loan entity</strong> — no principal, no APR, no term, no amortization schedule, no monthly payment field. (<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>)</li>
+		<li>A mortgage, a car loan, a student loan — none can be represented. They appear, at best, as expenses (the monthly payment) with no link to the underlying debt.</li>
+		<li>No <strong>payoff planner</strong> — the app cannot show "avalanche vs. snowball, total interest difference, debt-free date." That single view is what makes a debt plan real.</li>
+		<li>The credit card (Lesson 4) is the most expensive debt most households carry, and it cannot be modelled as debt either.</li>
+	</ul>
+	<p>Debt is the heaviest item on most households' balance sheets. An app that cannot show it
+	cannot help manage it.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>List every debt you owe: balance, APR, minimum payment, term. Sort by APR (avalanche). Note
+how much spare cash you can put above the minimums each month. That spare cash, aimed at the top
+of the list until it is gone, then rolled onto the next — is a complete debt-elimination plan you
+can hold in one paragraph.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you can read a loan and choose a strategy."
+	data-msg-retry="Re-read amortization and the two strategies, then retry.">
+	<h3>Debt drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="interest" data-reason="Early payments are mostly interest because interest is charged on the still-large outstanding principal. Principal reduction comes later.">
+		<p class="quiz-prompt">In an amortization schedule, early payments are mostly:</p>
+		<div class="quiz-options">
+			<button data-choice="principal">principal</button>
+			<button data-choice="interest">interest</button>
+			<button data-choice="fees">fees</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="avalanche" data-reason="Avalanche targets highest APR first — mathematically the least total interest.">
+		<p class="quiz-prompt">Which strategy costs the least total interest?</p>
+		<div class="quiz-options">
+			<button data-choice="snowball">Snowball</button>
+			<button data-choice="avalanche">Avalanche</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="snowball" data-reason="Snowball targets smallest balance first — balances hit zero fast, building momentum. Slightly more interest but more motivating.">
+		<p class="quiz-prompt">Which strategy gives the fastest visible wins (balances hitting zero)?</p>
+		<div class="quiz-options">
+			<button data-choice="snowball">Snowball</button>
+			<button data-choice="avalanche">Avalanche</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="highest-apr" data-reason="Both strategies pay minimums on all debts, then put all spare cash at the target. Avalanche's target is the highest-APR debt.">
+		<p class="quiz-prompt">Under avalanche, you put all spare cash against the ____ debt.</p>
+		<div class="quiz-options">
+			<button data-choice="highest-apr">highest-APR</button>
+			<button data-choice="smallest-balance">smallest-balance</button>
+			<button data-choice="oldest">oldest</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="decades" data-reason="Paying only the ~2% minimum on a credit-card balance takes decades and costs more in interest than the original purchase — the most expensive habit a household can have.">
+		<p class="quiz-prompt">Paying only the minimum on a credit card takes:</p>
+		<div class="quiz-options">
+			<button data-choice="months">a few months</button>
+			<button data-choice="decades">decades</button>
+			<button data-choice="one-year">about one year</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.khanacademy.org/college-careers-more/personal-finance">Khan Academy — Personal Finance, "Credit &amp; Debt" units.</a></strong>
+	Worked amortization examples and the math of compound interest on debt — the clearest free
+	resource for the mechanics behind this lesson. Use it to confirm the avalanche numbers before
+	spec'ing a payoff planner.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Is a mortgage 'good debt' worth keeping for the tax deduction?"
+		"When does investing beat paying down a low-APR loan?" "Should I refinance before avalanching?"
+		— ask.
+	</div>
+	<nav>
+		<span>← <a href="0010-sinking-funds.html">Lesson 10: Sinking funds</a></span>
+		<span><a href="0012-investing-basics.html">Lesson 12: Investing basics</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0012-investing-basics.html
+++ b/finance-lessons/lessons/0012-investing-basics.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 12 — Investing basics</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 12 · The long game</p>
+	<h1>Investing basics: why cash loses, and how net worth grows</h1>
+	<p class="lesson-meta">Continues <a href="0011-debt-and-loans.html">Lesson 11</a> · ~9 minutes · grounded in <a href="../reference/hoalu-financial-audit.html">Audit, missing features</a></p>
+</header>
+
+<p>Saving preserves money. <em>Investing</em> grows it. The distinction is not optional: over
+decades, cash loses to inflation; invested capital compounds. This lesson is why the balance sheet
+(Lesson 2) needs an investment line — and why Hoalu, which has no investment entity, cannot show
+the engine that actually builds wealth.</p>
+
+<h2>The three forces</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Inflation</dt><dd>The slow rise in prices that erodes the purchasing power of idle cash. A bank balance earning nothing loses real value every year.</dd></div>
+	<div class="def-row"><dt>Compounding</dt><dd>Returns earned on prior returns. The longer money is invested, the steeper the curve — most of the growth happens in the later years.</dd></div>
+	<div class="def-row"><dt>Risk premium</dt><dd>The extra return markets pay for taking on risk (stocks over bonds over cash). Higher expected return is the reward for accepting volatility.</dd></div>
+</div>
+
+<p>The household question is not <em>whether</em> to invest but <em>how much of the balance sheet</em>
+belongs in growth assets versus cash. Cash covers needs and near-term goals (Lessons 3, 10);
+investments cover the long game — money you will not touch for years.</p>
+
+<h2>The simplest portfolio most people need</h2>
+
+<aside class="note">
+	<b>Source.</b> J.L. Collins's <i>The Simple Path to Wealth</i> and the Bogleheads wiki both land
+	on the same answer for non-professionals: a small number of low-cost, broad-market <strong>index
+	funds</strong>, held for decades. No stock-picking, no market timing.
+</aside>
+
+<p>A <strong>broad-market index fund</strong> holds a tiny slice of every company in a market, so
+you own the whole market's average return at near-zero cost. The classic
+<strong>three-fund portfolio</strong> is: a domestic stock index, an international stock index, and
+a bond index. The split between stocks and bonds sets your risk: more stocks = more growth and more
+volatility; more bonds = calmer but slower. Age and time horizon decide the mix.</p>
+
+<table>
+	<thead><tr><th></th><th>Cash / savings</th><th>Bonds</th><th>Stocks (index)</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Return</strong></td><td>Lowest</td><td>Low</td><td>Highest (long-run)</td></tr>
+		<tr><td><strong>Risk</strong></td><td>Lowest</td><td>Low</td><td>Highest (short-run)</td></tr>
+		<tr><td><strong>Time horizon</strong></td><td>0–1 yr</td><td>1–5 yr</td><td>5–10+ yr</td></tr>
+		<tr><td><strong>Job</strong></td><td>Reserve + sinking</td><td>Steady</td><td>Growth</td></tr>
+	</tbody>
+</table>
+
+<h2>The one graph that changes behaviour</h2>
+
+<p>Compounding is a curve, not a line. Invest 1,000,000 ₫/month at a 7% real return:</p>
+<ul>
+	<li>After 10 years: ~170,000,000 ₫ (you put in 120,000,000)</li>
+	<li>After 20 years: ~520,000,000 ₫ (you put in 240,000,000)</li>
+	<li>After 30 years: ~1,200,000,000 ₫ (you put in 360,000,000)</li>
+</ul>
+<p>The contributions tripled; the result grew sevenfold from year 10 to year 30. The <em>last</em>
+years did most of the work. The lesson: <strong>start now, not later</strong> — a decade of delay
+costs more than it seems, because the missed years are the ones that would have compounded
+hardest.</p>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the growth engine is absent</p>
+	<ul>
+		<li>There is <strong>no investment account entity, no holdings, no tickers, no portfolio valuation</strong>. "Investments" is only an income-category name. (<a href="../reference/hoalu-financial-audit.html">Audit, missing features</a>)</li>
+		<li>The balance sheet (Lesson 2) therefore cannot show the line that actually grows net worth over decades — only static cash and depreciating assets.</li>
+		<li>Without an investment line, the app cannot chart <strong>net-worth-over-time</strong> in a way that means anything, because the curve that should dominate the chart is missing.</li>
+	</ul>
+	<p>The smallest useful version: an investment account with manual holdings and a current value
+	(market value as a stock), feeding net worth. Automatic price feeds and rebalancing come later —
+	the user first needs the line to exist at all.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>If you have no investments: open a brokerage, buy one broad-market index fund, set a small
+monthly auto-invest. The amount matters less than <em>starting</em> — the curve in this lesson
+rewards time above all. If you already invest: list your holdings and their rough allocation
+(stocks vs bonds vs cash). That allocation is your real risk dial; the app should eventually hold
+it.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you know why cash loses and capital grows."
+	data-msg-retry="Re-read inflation, compounding, and the three-fund idea, then retry.">
+	<h3>Investing drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="inflation" data-reason="Inflation erodes the purchasing power of idle cash — a bank balance earning nothing loses real value every year.">
+		<p class="quiz-prompt">What silently erodes the real value of idle cash?</p>
+		<div class="quiz-options">
+			<button data-choice="inflation">inflation</button>
+			<button data-choice="taxes">taxes</button>
+			<button data-choice="fees">fees</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="compounding" data-reason="Compounding — returns on prior returns — makes the curve steepen. Most growth happens in the later years.">
+		<p class="quiz-prompt">What makes an investment curve steepen over decades?</p>
+		<div class="quiz-options">
+			<button data-choice="luck">luck</button>
+			<button data-choice="compounding">compounding</button>
+			<button data-choice="leverage">leverage</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="index-fund" data-reason="A broad-market index fund holds a slice of every company in a market, capturing the market's average return at near-zero cost — no stock-picking.">
+		<p class="quiz-prompt">The simplest long-run holding for most non-professionals is a low-cost:</p>
+		<div class="quiz-options">
+			<button data-choice="index-fund">broad-market index fund</button>
+			<button data-choice="single-stock">single stock</button>
+			<button data-choice="savings-account">savings account</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="time" data-reason="The curve rewards time above all — the last years do most of the work, so a decade of delay costs more than it seems.">
+		<p class="quiz-prompt">What matters most for compounding — amount or time?</p>
+		<div class="quiz-options">
+			<button data-choice="amount">the amount</button>
+			<button data-choice="time">the time</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="absent" data-reason="Hoalu has no investment account, no holdings, no valuation — the growth line of the balance sheet is missing entirely. (Audit, missing features)">
+		<p class="quiz-prompt">In Hoalu today, the investment line of the balance sheet is:</p>
+		<div class="quiz-options">
+			<button data-choice="present">present and tracked</button>
+			<button data-choice="absent">absent entirely</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary source to read next</p>
+	<p><strong><a href="https://www.jlcollinsnh.com/">The Simple Path to Wealth</a> — J.L. Collins.</strong>
+	The clearest case for broad-market index investing, the behaviour that makes it work (do
+	nothing, through crashes), and the maths of the 4% withdrawal that Lesson 13 builds on. The book
+	the whole "long game" half of this course leans on.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "How do I pick a stock/bond split for my age?" "What do I do when the
+		market crashes?" "Are Vietnam-specific index funds right for me?" — ask. (Jurisdiction
+		answers depend on your country — confirm it first.)
+	</div>
+	<nav>
+		<span>← <a href="0011-debt-and-loans.html">Lesson 11: Debt &amp; loans</a></span>
+		<span><a href="0013-financial-independence.html">Lesson 13: Financial independence</a> →</span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/0013-financial-independence.html
+++ b/finance-lessons/lessons/0013-financial-independence.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lesson 13 — Financial independence</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+</head>
+<body>
+<article class="lesson">
+
+<header class="lesson-header">
+	<p class="lesson-kicker">Lesson 13 · The capstone</p>
+	<h1>Financial independence &amp; the 4% rule</h1>
+	<p class="lesson-meta">Continues <a href="0012-investing-basics.html">Lesson 12</a> · ~10 minutes · closes the course</p>
+</header>
+
+<p>Every previous lesson feeds this one. The balance sheet (2), the savings rate (5), the
+investment engine (12) — together they answer the only long question a household's money really
+asks: <em>when does work become optional?</em></p>
+
+<h2>The crossover point</h2>
+
+<div class="callout">
+	<p class="callout-title def">Definition</p>
+	<div class="def-row"><dt>Crossover point</dt><dd>The moment your investments can generate enough to cover your expenses forever — at which point work becomes optional. <em>Your Money or Your Life</em>'s central idea.</dd></div>
+	<div class="def-row"><dt>FI number</dt><dd>The invested net worth needed to hit the crossover. <strong>FI number ≈ annual expenses ÷ withdrawal rate.</strong></dd></div>
+</div>
+
+<p>So the FI number is set by your <em>expenses</em>, not your income — another reason the savings
+rate (Lesson 5) is the lever that matters most. Two people with the same investments but different
+expenses reach FI at different times; the lower-spender crosses first.</p>
+
+<h2>The 4% rule</h2>
+
+<p>The <strong>4% rule</strong> comes from the <em>Trinity study</em> (and William Bengen's
+earlier work): a portfolio of roughly half stocks, half bonds, withdrawing 4% of the starting
+balance in year one and adjusting that amount for inflation each year after, has historically
+lasted 30+ years across nearly all market sequences. So a 25× expenses portfolio is the rough FI
+target:</p>
+
+<p style="text-align:center;font-family:var(--sans);font-size:1rem"><strong>FI number ≈ annual expenses × 25</strong></p>
+
+<aside class="note">
+	<b>Not a guarantee.</b> 4% is a historically safe rate, not a promise — future returns are
+	unknown, and a bad sequence early in retirement (sequence-of-returns risk) can break a plan that
+	averages fine. Use 4% as a planning anchor; many now prefer ~3.5% for longer horizons. Verify
+	against current research in the primary sources before relying on it.
+</aside>
+
+<h2>The lever: savings rate sets time-to-FI</h2>
+
+<p>Because the FI target is a multiple of <em>expenses</em>, and your savings rate is
+<em>income − expenses ÷ income</em>, the savings rate alone determines how many years you must
+work — almost regardless of income. This is the "shockingly simple math" popularised by Mr. Money
+Mustache. The shape (not exact figures — verify in the source):</p>
+
+<table>
+	<thead><tr><th>Savings rate</th><th>≈ Years to FI (from zero)</th></tr></thead>
+	<tbody>
+		<tr><td>10%</td><td>~50</td></tr>
+		<tr><td>25%</td><td>~30</td></tr>
+		<tr><td>50%</td><td>~17</td></tr>
+		<tr><td>75%</td><td>~7</td></tr>
+	</tbody>
+</table>
+<p style="font-family:var(--sans);font-size:0.78rem;color:var(--ink-faint)">Approximate, assumes ~5% real returns and starting from zero invested. Confirm exact figures against the primary source.</p>
+
+<p>Read it twice: <strong>halving your time to FI does not require doubling your income — it
+requires raising your savings rate.</strong> A household saving 10% works roughly five times longer
+than one saving 75%, at the same income. This is why the dashboard's missing savings-rate card
+(Lesson 5) is not a cosmetic gap — it hides the number that sets the family's whole timeline.</p>
+
+<h2>What Hoalu would need to show this</h2>
+
+<div class="callout">
+	<p class="callout-title app">In Hoalu — the capstone cannot be built yet</p>
+	<p>Every input to FI exists conceptually in this course, but each maps to a feature Hoalu lacks:</p>
+	<ul>
+		<li><strong>Annual expenses</strong> → Hoalu has the expense data, but no reliable multi-currency annual sum (Lesson 9 defects).</li>
+		<li><strong>Invested net worth</strong> → no investment entity, no holdings, no valuation (Lesson 12).</li>
+		<li><strong>Savings rate</strong> → never computed (Lesson 5).</li>
+		<li><strong>FI number &amp; time-to-FI</strong> → no calculator, no projection, no runway.</li>
+	</ul>
+	<p>FI is the natural capstone feature: <em>one screen</em> that takes your annual expenses, your
+	invested net worth, your savings rate, and shows your FI number, your progress, and your
+	projected crossover year. It is the whole course in one chart — and it is also the proof that
+	every earlier lesson's gap must be closed first, because the chart is only as honest as its
+	inputs.</p>
+</div>
+
+<h2>The win</h2>
+
+<p>Compute your rough FI number tonight: last year's expenses × 25. Compare it to your invested
+net worth today. The ratio is your progress toward crossover. Then look at your savings rate
+(Lesson 5's win) and find your row in the table above. You now hold the two numbers that govern
+your family's financial timeline — and a concrete spec for the screen Hoalu should one day show
+you.</p>
+
+<div class="quiz" data-quiz
+	data-msg-perfect="All correct — you understand the crossover and the lever."
+	data-msg-retry="Re-read the FI number formula and the savings-rate table, then retry.">
+	<h3>FI drill</h3>
+	<p class="quiz-score"></p>
+
+	<div class="quiz-item" data-answer="expenses" data-reason="FI number ≈ annual expenses × 25. It is set by expenses, not income — the lower-spender crosses first.">
+		<p class="quiz-prompt">The FI number is a multiple of your annual:</p>
+		<div class="quiz-options">
+			<button data-choice="income">income</button>
+			<button data-choice="expenses">expenses</button>
+			<button data-choice="savings">savings</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="9000000000" data-reason="Monthly 30M × 12 = 360M annual; × 25 = 9,000,000,000 ₫. The FI number is annual expenses × 25.">
+		<p class="quiz-prompt">Monthly expenses 30,000,000 ₫. FI number (×25) is:</p>
+		<div class="quiz-options">
+			<button data-choice="9000000000">9,000,000,000 ₫</button>
+			<button data-choice="750000000">750,000,000 ₫</button>
+			<button data-choice="30000000">30,000,000 ₫</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="4" data-reason="The Trinity study / Bengen found ~4% (of the starting balance, inflation-adjusted after) historically lasted 30+ years across most sequences. ×25 is its inverse.">
+		<p class="quiz-prompt">The historically-safe withdrawal rate that gives the "×25" rule is:</p>
+		<div class="quiz-options">
+			<button data-choice="4">4%</button>
+			<button data-choice="10">10%</button>
+			<button data-choice="1">1%</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="savings-rate" data-reason="Because the FI target is a multiple of expenses and savings rate is (income−expenses)÷income, the savings rate alone sets time-to-FI, almost regardless of income.">
+		<p class="quiz-prompt">What single number most sets your years to FI?</p>
+		<div class="quiz-options">
+			<button data-choice="income">your income</button>
+			<button data-choice="savings-rate">your savings rate</button>
+			<button data-choice="age">your age</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<div class="quiz-item" data-answer="halves" data-reason="Raising the savings rate shortens years to FI sharply — moving from 10% to ~50% roughly cuts a ~50-year timeline to ~17. Doubling income does not do that.">
+		<p class="quiz-prompt">Raising the savings rate (not income) roughly ____ the years to FI.</p>
+		<div class="quiz-options">
+			<button data-choice="halves">halves or better</button>
+			<button data-choice="doubles">doubles</button>
+			<button data-choice="unchanged">leaves unchanged</button>
+		</div>
+		<p class="quiz-feedback"></p>
+	</div>
+
+	<p class="quiz-complete"></p>
+</div>
+
+<div class="callout">
+	<p class="callout-title source">Primary sources to read next</p>
+	<p><strong><a href="https://www.jlcollinsnh.com/">The Simple Path to Wealth</a> — J.L. Collins</strong>
+	for the 4% rule and behaviour; and <strong><a href="https://www.bogleheads.org/wiki/Bogleheads%C2%AE_investment_philosophy">the Bogleheads wiki</a></strong>
+	for safe-withdrawal detail and the three-fund portfolio. Together they are the rigorous backbone
+	of everything in this capstone.</p>
+</div>
+
+<footer class="lesson-footer">
+	<div class="questions">
+		<b>Ask your teacher.</b> "Is 4% still safe given current valuations?" "What's
+		sequence-of-returns risk?" "How do I plan FI with a mortgage still outstanding?" — ask. And
+		ask anything across the whole course: this is the capstone, but the teacher is still here.
+	</div>
+	<nav>
+		<span>← <a href="0012-investing-basics.html">Lesson 12: Investing basics</a></span>
+		<span>↳ <a href="../reference/hoalu-financial-audit.html">Revisit the Audit</a> · <a href="../reference/glossary.html">Glossary</a></span>
+	</nav>
+</footer>
+
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>

--- a/finance-lessons/lessons/index.html
+++ b/finance-lessons/lessons/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Money Management — Course Index</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+<style>
+	.idx-header { border-bottom: 1px solid var(--rule); padding-bottom: 1.2rem; margin-bottom: 2rem; }
+	.idx-header h1 { font-size: 1.9rem; margin: 0 0 0.3rem; }
+	.idx-header p { margin: 0; font-family: var(--sans); font-size: 0.85rem; color: var(--ink-faint); }
+	.arc { margin: 0 0 1.8rem; }
+	.arc h2 { font-size: 0.78rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin: 0 0 0.6rem; font-family: var(--sans); font-weight: 600; }
+	.arc ol { list-style: none; padding: 0; margin: 0; counter-reset: lesson; }
+	.arc li { counter-increment: lesson; padding: 0.5rem 0; border-bottom: 1px solid var(--rule-soft); display: grid; grid-template-columns: 2.2rem 1fr; gap: 0.5rem; align-items: baseline; }
+	.arc li::before { content: counter(lesson, decimal-leading-zero); font-family: var(--sans); font-size: 0.75rem; color: var(--ink-faint); }
+	.arc li a { font-weight: 600; }
+	.arc li .desc { grid-column: 2; font-family: var(--sans); font-size: 0.8rem; color: var(--ink-soft); margin-top: 0.1rem; }
+	.refs { margin-top: 2.5rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); font-family: var(--sans); font-size: 0.85rem; }
+</style>
+</head>
+<body>
+<article class="lesson">
+<header class="idx-header">
+	<h1>Money Management for Hoalu</h1>
+	<p>A 13-lesson course: learn personal &amp; family finance, then audit and improve the Hoalu app. Each lesson is short, has an interactive drill, and ties to a concrete gap in the app. Start at 1, or jump to any.</p>
+</header>
+
+<section class="arc">
+	<h2>Arc 1 — Foundations: the half Hoalu is blind to</h2>
+	<ol>
+		<li><a href="0001-stock-vs-flow.html">Stock vs. Flow</a><div class="desc">The one distinction that explains why Hoalu feels like a spending diary. The app tracks flows; it has no stocks.</div></li>
+		<li><a href="0002-the-balance-sheet.html">The Balance Sheet</a><div class="desc">Assets, liabilities, net worth — the scoreboard Hoalu cannot show.</div></li>
+		<li><a href="0003-accounts-done-right.html">Accounts done right</a><div class="desc">The five account types, the data each must carry, and why opening balance is non-negotiable.</div></li>
+		<li><a href="0004-credit-cards-as-debt.html">Credit cards as debt</a><div class="desc">Limit, balance owed, available credit, grace period, APR — the card is a loan, not a wallet.</div></li>
+	</ol>
+</section>
+
+<section class="arc">
+	<h2>Arc 2 — The cash-flow half: the engine, measured</h2>
+	<ol>
+		<li><a href="0005-cash-flow-and-savings-rate.html">Cash flow &amp; the savings rate</a><div class="desc">The single most predictive number — and the cheapest, highest-value card Hoalu is missing.</div></li>
+		<li><a href="0006-transfers.html">Transfers</a><div class="desc">Why moving your own money is neither income nor expense, and why fake transfers corrupt the numbers.</div></li>
+		<li><a href="0007-budgeting-systems.html">Budgeting systems</a><div class="desc">50/30/20 vs. category budgets vs. zero-based. A plan, not just a record.</div></li>
+	</ol>
+</section>
+
+<section class="arc">
+	<h2>Arc 3 — Operations: getting the plumbing right</h2>
+	<ol>
+		<li><a href="0008-recurring-bills.html">Recurring bills done right</a><div class="desc">Hoalu's strongest feature — plus the dueDay=0 bug, the subscription audit, and silent behaviour as a sin.</div></li>
+		<li><a href="0009-multi-currency.html">Multi-currency done right</a><div class="desc">Rate at the transaction date, and the five FX defects that silently corrupt Hoalu's totals.</div></li>
+		<li><a href="0010-sinking-funds.html">Savings goals &amp; sinking funds</a><div class="desc">Turn known future lumps into smooth monthly contributions; the future gets an address.</div></li>
+	</ol>
+</section>
+
+<section class="arc">
+	<h2>Arc 4 — The long game: building net worth over time</h2>
+	<ol>
+		<li><a href="0011-debt-and-loans.html">Debt &amp; loans</a><div class="desc">Amortization, the minimum-payment trap, and avalanche vs. snowball.</div></li>
+		<li><a href="0012-investing-basics.html">Investing basics</a><div class="desc">Inflation, compounding, the three-fund portfolio — the growth line the balance sheet needs.</div></li>
+		<li><a href="0013-financial-independence.html">Financial independence &amp; the 4% rule</a><div class="desc">The capstone: FI number, the 4% rule, and how the savings rate sets the whole timeline.</div></li>
+	</ol>
+</section>
+
+<div class="refs">
+	<strong>Reference:</strong>
+	<a href="../reference/hoalu-financial-audit.html">Hoalu Financial Audit</a> ·
+	<a href="../reference/glossary.html">Glossary</a> ·
+	<a href="../MISSION.md">Mission</a> ·
+	<a href="../RESOURCES.md">Resources</a>
+</div>
+</article>
+</body>
+</html>

--- a/finance-lessons/reference/glossary.html
+++ b/finance-lessons/reference/glossary.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Glossary — Money Management</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+<style>
+	.gloss-header { border-bottom: 1px solid var(--rule); padding-bottom: 1.2rem; margin-bottom: 2rem; }
+	.gloss-header h1 { font-size: 1.8rem; margin: 0 0 0.3rem; }
+	.gloss-header p { margin: 0; font-family: var(--sans); font-size: 0.82rem; color: var(--ink-faint); }
+	dl.term { margin: 0 0 1.5rem; }
+	dl.term dt { font-weight: 600; font-family: var(--serif); margin-top: 0.6rem; }
+	dl.term dt .alias { font-family: var(--sans); font-weight: 400; font-size: 0.78rem; color: var(--ink-faint); }
+	dl.term dd { margin: 0.15rem 0 0 0; }
+	dl.term dd .avoid { font-family: var(--sans); font-size: 0.76rem; color: var(--ink-faint); }
+	section h2 { font-size: 1.1rem; margin: 2rem 0 0.4rem; border-bottom: 1px solid var(--rule-soft); padding-bottom: 0.3rem; }
+</style>
+</head>
+<body>
+<article class="lesson">
+<header class="gloss-header">
+	<h1>Glossary</h1>
+	<p>The canonical language of this course. Every lesson adheres to these terms; update in place as understanding deepens.</p>
+</header>
+
+<section>
+<h2>Foundations</h2>
+<dl class="term">
+	<dt>Stock <span class="alias">— point-in-time quantity</span></dt>
+	<dd>A quantity measured at a single moment. "How much right now?" — a bank balance today, debt as of a date, net worth this instant.</dd>
+	<dd class="avoid">Avoid: amount, total (ambiguous with flow).</dd>
+
+	<dt>Flow <span class="alias">— period quantity</span></dt>
+	<dd>A quantity measured over a period. "How much moved during March?" — salary earned this month, groceries spent this month, a savings rate.</dd>
+	<dd class="avoid">Avoid: amount, total (ambiguous with stock).</dd>
+
+	<dt>Balance sheet</dt>
+	<dd>The stock statement — assets and liabilities at a single date, yielding net worth. A snapshot, not a range.</dd>
+
+	<dt>Cash-flow statement</dt>
+	<dd>The flow statement — income and expenses over a date range, yielding savings. The engine that changes the balance sheet.</dd>
+
+	<dt>Net worth</dt>
+	<dd>Assets − liabilities, at a single date. The scoreboard; the true measure of financial position.</dd>
+	<dd class="avoid">Avoid: wealth (vague), balance (means a stock on one account, not the whole sheet).</dd>
+</dl>
+</section>
+
+<section>
+<h2>Balance sheet</h2>
+<dl class="term">
+	<dt>Asset</dt>
+	<dd>Something you own that holds value — cash, savings, a car, a home, investments. A stock.</dd>
+
+	<dt>Liability</dt>
+	<dd>Something you owe — a card balance, a loan, a mortgage, unpaid tax. A stock.</dd>
+
+	<dt>Opening balance</dt>
+	<dd>The amount in an account at the moment you start tracking. Without it, no current balance can reconcile.</dd>
+
+	<dt>Reconciliation identity</dt>
+	<dd>current balance = opening + Σ income − Σ expenses − Σ transfers out + Σ transfers in. The rule every account must satisfy.</dd>
+
+	<dt>Credit limit</dt>
+	<dd>The most a card lender will let you owe at once. A stock, set by the bank.</dd>
+
+	<dt>Balance owed <span class="alias">— outstanding balance</span></dt>
+	<dd>What you currently owe on a credit card. A stock that rises with purchases, falls with payments.</dd>
+
+	<dt>Available credit</dt>
+	<dd>Credit limit − balance owed. How much more you can spend right now.</dd>
+
+	<dt>Statement balance</dt>
+	<dd>What you owed on the statement closing date. Paying this in full by the due date avoids all interest.</dd>
+
+	<dt>Grace period</dt>
+	<dd>The window between the statement closing date and the payment due date, during which no interest accrues — if the statement balance is paid in full.</dd>
+
+	<dt>APR <span class="alias">— annual percentage rate</span></dt>
+	<dd>The yearly interest rate applied to any card balance carried past the due date.</dd>
+
+	<dt>Utilisation</dt>
+	<dd>Balance owed ÷ credit limit. A high ratio hurts creditworthiness; the live constraint to watch.</dd>
+
+	<dt>Transactor</dt>
+	<dd>A cardholder who pays the statement balance in full each month — pays no interest, uses the bank's money free.</dd>
+
+	<dt>Revolver</dt>
+	<dd>A cardholder who carries a balance past the due date — pays interest, the card is a liability.</dd>
+</dl>
+</section>
+
+<section>
+<h2>Cash flow</h2>
+<dl class="term">
+	<dt>Income</dt>
+	<dd>Money earned from outside the household over a period — a flow in. Increases net worth.</dd>
+
+	<dt>Expense</dt>
+	<dd>Money spent on consumed goods/services over a period — a flow out. Decreases net worth.</dd>
+
+	<dt>Savings <span class="alias">— cash flow (positive)</span></dt>
+	<dd>Income − expenses over a period, when positive. "Not spent," wherever it lands — cash, debt paydown, or investments.</dd>
+
+	<dt>Savings rate</dt>
+	<dd>Savings ÷ income × 100, over a month or year. The percentage of income kept; the single most predictive number for financial trajectory.</dd>
+
+	<dt>Transfer</dt>
+	<dd>Moving money between accounts you own. Changes where money sits, not how much you have — no effect on cash flow or net worth.</dd>
+
+	<dt>Recurring floor</dt>
+	<dd>The total monthly cost of all recurring bills and subscriptions. The minimum the household must clear before any discretionary spending.</dd>
+</dl>
+</section>
+
+<section>
+<h2>Planning</h2>
+<dl class="term">
+	<dt>Budget</dt>
+	<dd>A plan for spending, set before the period begins — a cap or allocation. Distinct from a record (what was spent).</dd>
+
+	<dt>Cap</dt>
+	<dd>The maximum planned for a category in a period. The budget number compared against actual spend.</dd>
+
+	<dt>Zero-based budgeting</dt>
+	<dd>A system that gives every unit of income a job before spending, so income − allocations = 0. Tightest control.</dd>
+
+	<dt>Envelope <span class="alias">— allocation</span></dt>
+	<dd>A labelled slice of money assigned to a purpose within a single account — the fund exists as a label, not a separate bank account.</dd>
+
+	<dt>50/30/20</dt>
+	<dd>A proportion rule: ~50% needs, ~30% wants, ~20% savings/debt. The simplest budgeting system; coarsest control.</dd>
+
+	<dt>Rollover</dt>
+	<dd>Carrying a category's underspend forward as next month's buffer, or overspend as a debt against next month's cap.</dd>
+
+	<dt>Sinking fund</dt>
+	<dd>Money set aside gradually for a known future expense of known amount and date. Monthly contribution = target ÷ months remaining.</dd>
+
+	<dt>Emergency fund</dt>
+	<dd>Reserve for unknown bad events, typically 3–6 months of expenses. Distinct from sinking funds (which are for known future expenses).</dd>
+</dl>
+</section>
+
+<section>
+<h2>Debt</h2>
+<dl class="term">
+	<dt>Principal</dt>
+	<dd>The amount of a loan still owed — the part you pay down. A stock.</dd>
+
+	<dt>Interest</dt>
+	<dd>The cost of borrowing, charged each period on the outstanding principal. A flow.</dd>
+
+	<dt>Term</dt>
+	<dd>The number of scheduled payments to clear a loan.</dd>
+
+	<dt>Amortization</dt>
+	<dd>The schedule splitting each fixed payment into interest and principal reduction. Early payments are mostly interest; late ones mostly principal.</dd>
+
+	<dt>Minimum payment</dt>
+	<dd>The lowest a lender will accept. Sized to stretch the loan across the full term, maximising interest paid — a trap.</dd>
+
+	<dt>Avalanche</dt>
+	<dd>A debt-payoff strategy targeting the highest-APR debt first. Mathematically the least total interest.</dd>
+
+	<dt>Snowball</dt>
+	<dd>A debt-payoff strategy targeting the smallest balance first. Slightly more interest, but faster visible wins for motivation.</dd>
+</dl>
+</section>
+
+<section>
+<h2>Investing</h2>
+<dl class="term">
+	<dt>Inflation</dt>
+	<dd>The slow rise in prices that erodes the purchasing power of idle cash.</dd>
+
+	<dt>Compounding</dt>
+	<dd>Returns earned on prior returns. The longer money is invested, the steeper the curve — most growth is in the later years.</dd>
+
+	<dt>Index fund</dt>
+	<dd>A low-cost fund holding a slice of every company in a market, capturing the market's average return. No stock-picking.</dd>
+
+	<dt>Three-fund portfolio</dt>
+	<dd>A simple portfolio of domestic stocks, international stocks, and bonds. The split between stocks and bonds sets the risk.</dd>
+
+	<dt>Risk premium</dt>
+	<dd>The extra return markets pay for accepting risk (stocks over bonds over cash).</dd>
+</dl>
+</section>
+
+<section>
+<h2>Financial independence</h2>
+<dl class="term">
+	<dt>Crossover point</dt>
+	<dd>The moment investments can generate enough to cover expenses forever — work becomes optional.</dd>
+
+	<dt>FI number <span class="alias">— financial-independence number</span></dt>
+	<dd>The invested net worth needed to hit the crossover. ≈ annual expenses ÷ withdrawal rate (≈ ×25 at 4%).</dd>
+
+	<dt>4% rule</dt>
+	<dd>A historically-safe withdrawal rate: withdraw 4% of the starting balance in year one, adjust for inflation after. Inverse of "×25."</dd>
+
+	<dt>Withdrawal rate</dt>
+	<dd>The percentage of a portfolio drawn each year in retirement. Lower is safer; 3.5% is often preferred for longer horizons.</dd>
+
+	<dt>Sequence-of-returns risk</dt>
+	<dd>The danger that poor market returns early in retirement break a plan that averages fine over the period.</dd>
+</dl>
+</section>
+
+<hr class="section" />
+<p style="font-family:var(--sans);font-size:0.78rem;color:var(--ink-faint)">Terms are added as the course teaches them. When understanding deepens or a definition turns out wrong, revise in place — do not leave stale entries.</p>
+</article>
+</body>
+</html>

--- a/finance-lessons/reference/hoalu-financial-audit.html
+++ b/finance-lessons/reference/hoalu-financial-audit.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Hoalu Financial Audit — Reference</title>
+<link rel="stylesheet" href="../assets/lesson.css" />
+<style>
+	.ref-header { border-bottom: 1px solid var(--rule); padding-bottom: 1.2rem; margin-bottom: 2rem; }
+	.ref-header h1 { font-size: 1.8rem; margin: 0 0 0.3rem; }
+	.ref-header p { margin: 0; font-family: var(--sans); font-size: 0.82rem; color: var(--ink-faint); }
+	.prio-high { color: var(--bad); font-weight: 600; }
+	.prio-med { color: var(--warn); font-weight: 600; }
+	.prio-low { color: var(--ink-faint); font-weight: 600; }
+	.tag { font-family: var(--sans); font-size: 0.7rem; padding: 0.1rem 0.4rem; border-radius: 3px; background: var(--paper-warm); border: 1px solid var(--rule); }
+</style>
+</head>
+<body>
+<article class="lesson">
+<header class="ref-header">
+	<h1>Hoalu Financial Audit</h1>
+	<p>Reference — what the app does today, what it lacks, what is financially wrong. <em>Read by every lesson; updated as the app and your understanding evolve.</em></p>
+</header>
+
+<h2>What Hoalu does today</h2>
+<ul>
+	<li><strong>Expense &amp; income tracking</strong> — full CRUD, multi-currency, attachments, AI quick-entry, receipt OCR.</li>
+	<li><strong>Recurring bills</strong> — schedules (daily/weekly/monthly/yearly), occurrence projection, overdue/today/upcoming view, "log payment" creates an expense and marks an occurrence paid.</li>
+	<li><strong>Event budgets</strong> — an event has a budget; the app sums FX-converted expenses linked to it and shows spent vs remaining.</li>
+	<li><strong>Dashboard</strong> — period cash-flow area chart, expense/income bar chart with outlier capping, three stat cards (income/expense/transactions) with period-over-period %, category breakdown, upcoming bills, recent transactions.</li>
+	<li><strong>Multi-currency display</strong> — FX rate table with time windows; cross-rate via USD; frontend and backend conversion paths.</li>
+	<li><strong>Workspaces &amp; members</strong> — multi-tenant, owner/admin/member roles, invitation system.</li>
+</ul>
+
+<h2>What a serious personal-finance app has — and Hoalu lacks</h2>
+<table>
+	<thead><tr><th>Missing feature</th><th>Why it matters financially</th><th>Priority</th></tr></thead>
+	<tbody>
+		<tr><td><strong>Wallet balances</strong> (opening, current)</td><td>The app cannot answer "how much money do I have right now?" — the most basic question in finance.</td><td class="prio-high">CRITICAL</td></tr>
+		<tr><td><strong>Net worth</strong> (assets − liabilities, over time)</td><td>Net worth is the true measure of financial position; income is only a means to grow it.</td><td class="prio-high">CRITICAL</td></tr>
+		<tr><td><strong>Transfers</strong> between wallets</td><td>Moving money between accounts is neither income nor expense. Without it, balances can't reconcile.</td><td class="prio-high">CRITICAL</td></tr>
+		<tr><td><strong>Credit-card debt modelling</strong></td><td>A credit card is a debt instrument (limit, balance owed, available, APR, due date). Hoalu treats it as a named wallet.</td><td class="prio-high">CRITICAL</td></tr>
+		<tr><td><strong>Per-category budgets</strong></td><td>Without budgets there is no spending plan, only a spending record.</td><td class="prio-med">HIGH</td></tr>
+		<tr><td><strong>Savings rate</strong></td><td>(Income − Expense) ÷ Income. The single number that predicts financial progress. Not computed anywhere.</td><td class="prio-med">HIGH</td></tr>
+		<tr><td><strong>Savings goals / envelopes</strong></td><td>Allocating money to future purposes (sinking funds). The app has no goal/allocation entity.</td><td class="prio-med">HIGH</td></tr>
+		<tr><td><strong>Debt &amp; loan tracking</strong></td><td>No loan entity, no amortization, no payoff planner (avalanche/snowball).</td><td class="prio-med">MEDIUM</td></tr>
+		<tr><td><strong>Investment tracking</strong></td><td>No holdings, tickers, or portfolio valuation. "Investments" is only an income-category name.</td><td class="prio-low">LATER</td></tr>
+		<tr><td><strong>Cash-flow projection / runway</strong></td><td>Upcoming bills are listed, but no "projected balance N days out" or "days until broke."</td><td class="prio-med">MEDIUM</td></tr>
+		<tr><td><strong>Recurring income generation</strong></td><td><code>income.repeat</code> exists but does nothing (no <code>recurringBillId</code>, no occurrence logic). A monthly salary never auto-projects.</td><td class="prio-med">HIGH</td></tr>
+		<tr><td><strong>Subcategories / hierarchy</strong></td><td>Categories are flat; no two-level nesting (Food → Groceries / Restaurants).</td><td class="prio-low">LOW</td></tr>
+		<tr><td><strong>Merchant/payee &amp; tags</strong></td><td>Expenses have no merchant, no tags. No vendor normalization or recurring-vendor detection.</td><td class="prio-low">LOW</td></tr>
+		<tr><td><strong>Transaction splits</strong></td><td>One expense = one category. Cannot split a single purchase across categories/wallets.</td><td class="prio-low">LOW</td></tr>
+		<tr><td><strong>Refund linkage</strong></td><td>No link between a refund and its original expense.</td><td class="prio-low">LOW</td></tr>
+		<tr><td><strong>Tax tracking</strong></td><td>No tax-deductible flag, no estimated-tax accruals.</td><td class="prio-low">JURISDICTION-DEPENDENT</td></tr>
+	</tbody>
+</table>
+
+<h2>Financially incorrect or questionable design</h2>
+
+<h3>1. Wallet has no balance at all <span class="tag">schema.ts:218</span></h3>
+<p>The <code>wallet</code> table has no <code>opening_balance</code>, <code>current_balance</code>, or <code>balance</code> column. The wallet list renders <em>no balance column</em>; <code>use-wallets.ts</code> computes a row <strong>count</strong>, not a sum. The app literally cannot show how much money is in any account.</p>
+
+<h3>2. Credit card is a plain wallet, not a debt <span class="tag">schema.ts:225</span></h3>
+<p><code>wallet.type</code> includes <code>"credit-card"</code> but there is no <code>credit_limit</code>, <code>balance_owed</code>, <code>available_credit</code>, <code>statement_balance</code>, <code>minimum_payment</code>, <code>apr</code>, or <code>due_date</code>. A credit card here is indistinguishable from a cash wallet, so credit-card debt is invisible.</p>
+
+<h3>3. Cash-flow "balance" starts from zero each period <span class="tag">cash-flow-chart.tsx</span></h3>
+<p>The dashboard's area chart plots a running cumulative (income − expense) that <strong>starts at 0</strong> for the selected period. It is not opening-balance + transactions. Changing the date range shows wildly different "balances" with no carried-forward figure — visually implying an account balance that doesn't exist.</p>
+
+<h3>4. Event <code>currency</code> vs frontend <code>budget_currency</code> mismatch <span class="tag">likely bug</span></h3>
+<p>DB column is <code>currency</code>; the frontend collection schema expects <code>budget_currency</code> and has no <code>currency</code> field. The sync proxy passes raw DB columns. Either events fail validation or the budget currency is <code>undefined</code> — breaking budget display for any event whose currency differs from the workspace default.</p>
+
+<h3>5. Single conversion date for a whole month <span class="tag">workspaces/repository.ts</span></h3>
+<p><code>convertAndSum</code> converts <strong>all</strong> transactions in a month using one month-end rate. An expense on the 1st and the 31st use the same rate, ignoring the rate on the actual transaction date. Misstates monthly totals for volatile currencies.</p>
+
+<h3>6. FX lookup uses <code>created_at</code>, not transaction <code>date</code> <span class="tag">use-expenses.ts, use-incomes.ts</span></h3>
+<p>Frontend FX lookup uses the row's insert timestamp. Backdated expenses get the rate from the data-entry moment, not the transaction date — a temporal mismatch that distorts history.</p>
+
+<h3>7. Missing FX rate silently zeroes the amount <span class="tag">silent data loss</span></h3>
+<p>No rate → multiplier 0 (frontend) or row skipped (backend). A USD expense in a VND workspace with no rate loaded contributes <strong>nothing</strong> to totals, with no warning to the user.</p>
+
+<h3>8. Primary-currency heuristic ignores the workspace setting <span class="tag">workspaces/repository.ts</span></h3>
+<p>Picks the currency of the wallet with the most expense <em>count</em>, so 100 tiny USD expenses beat 50 large VND ones — even though <code>workspace.metadata.currency</code> is already set on creation.</p>
+
+<h3>9. Recurring-bill <code>dueDay=0</code> is accepted but invalid <span class="tag">recurring-bills/schema.ts</span></h3>
+<p>Schema allows <code>dueDay</code> from <code>0</code> to <code>31</code>. For a monthly bill, <code>0</code> produces <code>new Date(y, m, 0)</code> = last day of the <em>previous</em> month — occurrences land in the wrong month. One field serves both weekly (0–6) and monthly (1–31) frequencies, so it cannot validate correctly.</p>
+
+<h3>10. "One-time" and "custom" recurring bills generate nothing <span class="tag">repository.ts</span></h3>
+<p><code>generateOccurrences</code> has branches only for daily/weekly/monthly/yearly. A "one-time recurring bill" is a contradiction but the schema permits it, producing zero occurrences silently.</p>
+
+<h3>11. <code>expense.repeat</code> and <code>income.repeat</code> are decorative <span class="tag">schema.ts</span></h3>
+<p>Unless linked to a <code>recurring_bill</code>, the <code>repeat</code> selector on every expense/income form does nothing. The PATCH handler explicitly refuses to auto-create a recurring bill. Income has <code>repeat</code> but no <code>recurringBillId</code> at all. The UI implies automation that does not exist.</p>
+
+<h3>12. Floating-point cross-rate maths <span class="tag">packages/finance</span></h3>
+<p>Rates are stored as <code>numeric(18,6)</code> (exact) but in-memory cross-rate uses <code>parseFloat</code> and float multiplication — inviting rounding drift in cross-currency sums.</p>
+
+<h2>Default categories seeded on workspace creation</h2>
+<p><span class="tag">auth.ts afterCreate</span> — one "Cash wallet" plus:</p>
+<table>
+	<thead><tr><th>Expense (9)</th><th>Income (5)</th></tr></thead>
+	<tbody>
+		<tr>
+			<td>Food &amp; Drink · Education · Shopping · Entertainment · Healthcare · Housing · Transportation · Gifts &amp; Donations · Uncategorized</td>
+			<td>Salary · Bonus · Business Revenue · Investments · Tax Refund</td>
+		</tr>
+	</tbody>
+</table>
+<p><strong>Notably absent:</strong> Savings, Debt Repayment, Insurance (as its own category), Taxes, Retirement — consistent with the absence of those features in the data model.</p>
+
+<hr class="section" />
+<p style="font-family:var(--sans);font-size:0.78rem;color:var(--ink-faint)">This reference is the single source of truth for "where Hoalu stands." Lessons cite it by section number. When the app changes or your understanding deepens, update it in place.</p>
+</article>
+<script src="../assets/quiz.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a self-contained personal & family money-management course grounded in the Hoalu app's actual financial gaps, plus static hosting on Fly.io.

## What's included

**Course (13 lessons, 4 arcs)** in `finance-lessons/lessons/`:
- Foundations: stock vs flow, balance sheet, accounts, credit cards as debt
- Cash flow: savings rate, transfers, budgeting systems
- Operations: recurring bills, multi-currency, sinking funds
- Long game: debt & loans, investing, financial independence

Each lesson is a self-contained HTML file with an interactive self-checking drill, ties to a concrete Hoalu gap, and recommends a primary source.

**Reference docs** in `finance-lessons/reference/`:
- `hoalu-financial-audit.html` — what the app does today, what it lacks, what is financially wrong (every lesson cites this)
- `glossary.html` — canonical terms for the course

**Shared assets** in `finance-lessons/assets/`: `lesson.css` (Tufte-style stylesheet), `quiz.js` (reusable quiz widget).

**Workspace meta**: `MISSION.md`, `RESOURCES.md`, `NOTES.md`, `learning-records/` (agent state; excluded from the deployed site).

## Hosting

Deployed to Fly.io as a static nginx site:
- URL: https://hoalu-finance-lessons.fly.dev/
- `Dockerfile`: `nginx:alpine` + copy content into `/usr/share/nginx/html`
- `fly.toml`: Singapore region, `internal_port = 80`, auto-stop machines (idle → stopped)
- Root `index.html` redirects to `lessons/index.html`
- `.dockerignore` keeps `NOTES.md` and `learning-records/` off the public site

Redeploy after edits: `flyctl deploy` from `finance-lessons/`.

Note: this adds non-code educational content alongside the app; it does not touch any app code.