### PR TITLE
chore: replace tabler with phosphor icons in navigation

### DIFF
--- a/apps/app/src/components/expenses/expense-filter-dropdown.tsx
+++ b/apps/app/src/components/expenses/expense-filter-dropdown.tsx
@@ -6,11 +6,12 @@ import {
 	FunnelIcon,
 	FadersHorizontalIcon,
 	ArrowsClockwiseIcon,
+	ShapesIcon,
 	TagIcon,
 	WalletIcon,
 	XIcon,
 } from "@hoalu/icons/phosphor";
-import { CaretRightFilledIcon, TriangleSquareCircleIcon } from "@hoalu/icons/tabler";
+import { CaretRightFilledIcon } from "@hoalu/icons/tabler";
 import { Badge } from "@hoalu/ui/badge";
 import { Button } from "@hoalu/ui/button";
 import { Calendar } from "@hoalu/ui/calendar";
@@ -223,7 +224,7 @@ export function ExpenseFilterDropdown() {
 								onClick={() => setCurrentView("amount")}
 							/>
 							<FilterMenuItem
-								icon={<TriangleSquareCircleIcon />}
+								icon={<ShapesIcon />}
 								label="Category"
 								active={hasActiveFilter("category")}
 								selected={currentView === "category"}

--- a/apps/app/src/components/layouts/mobile-layout.tsx
+++ b/apps/app/src/components/layouts/mobile-layout.tsx
@@ -1,10 +1,12 @@
 import {
+	ArrowsLeftRightIcon,
 	CheckIcon,
 	CaretUpDownIcon,
 	PaletteIcon,
 	MagnifyingGlassIcon,
+	SquaresFourIcon,
 } from "@hoalu/icons/phosphor";
-import { ArrowsExchangeIcon, LayoutDashboardIcon, SettingsIcon } from "@hoalu/icons/tabler";
+import { SettingsIcon } from "@hoalu/icons/tabler";
 import { Avatar, AvatarFallback } from "@hoalu/ui/avatar";
 import { Button } from "@hoalu/ui/button";
 import {
@@ -168,7 +170,7 @@ function MobileBottomNav() {
 						className: activeNavItemClass,
 					}}
 				>
-					<LayoutDashboardIcon className="size-6" aria-hidden="true" />
+					<SquaresFourIcon className="size-6" aria-hidden="true" />
 					<span className="truncate text-xs leading-none">Dashboard</span>
 				</ButtonLink>
 				<ButtonLink
@@ -182,7 +184,7 @@ function MobileBottomNav() {
 						className: activeNavItemClass,
 					}}
 				>
-					<ArrowsExchangeIcon className="size-6" aria-hidden="true" />
+					<ArrowsLeftRightIcon className="size-6" aria-hidden="true" />
 					<span className="truncate text-xs leading-none">Transactions</span>
 				</ButtonLink>
 				<ButtonLink

--- a/apps/app/src/components/layouts/nav-workspace.tsx
+++ b/apps/app/src/components/layouts/nav-workspace.tsx
@@ -1,15 +1,15 @@
-import { MagnifyingGlassIcon } from "@hoalu/icons/phosphor";
 import {
-	CalendarDollarIcon,
+	ArrowsLeftRightIcon,
+	CalendarStarIcon,
 	FileIcon,
-	LayoutDashboardIcon,
+	MagnifyingGlassIcon,
+	RepeatIcon,
+	ShapesIcon,
+	SquaresFourIcon,
 	TentIcon,
-	TriangleSquareCircleIcon,
-	UsersGroupIcon,
+	UsersIcon,
 	WalletIcon,
-	CalendarClockIcon,
-	ArrowsExchangeIcon,
-} from "@hoalu/icons/tabler";
+} from "@hoalu/icons/phosphor";
 import { Button } from "@hoalu/ui/button";
 import {
 	SidebarGroup,
@@ -52,7 +52,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug" params={{ slug }} activeOptions={{ exact: true }} />}
 								tooltip="Dashboard"
 							>
-								<LayoutDashboardIcon />
+								<SquaresFourIcon />
 								<span>Dashboard</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -75,7 +75,7 @@ export function NavWorkspace() {
 								}
 								tooltip="Transactions"
 							>
-								<ArrowsExchangeIcon />
+								<ArrowsLeftRightIcon />
 								<span>Transactions</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -85,7 +85,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug/recurring-bills" params={{ slug }} />}
 								tooltip="Recurring Bills"
 							>
-								<CalendarDollarIcon />
+								<RepeatIcon />
 								<span>Recurring Bills</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -95,7 +95,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug/events" params={{ slug }} />}
 								tooltip="Events"
 							>
-								<CalendarClockIcon />
+								<CalendarStarIcon />
 								<span>Events</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -109,7 +109,7 @@ export function NavWorkspace() {
 					<SidebarMenu>
 						<SidebarMenuItem>
 							<SidebarMenuButton render={<Link to="/$slug/categories" params={{ slug }} />}>
-								<TriangleSquareCircleIcon />
+								<ShapesIcon />
 								<span>Categories</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -143,7 +143,7 @@ export function NavWorkspace() {
 						</SidebarMenuItem>
 						<SidebarMenuItem>
 							<SidebarMenuButton render={<Link to="/$slug/settings/members" params={{ slug }} />}>
-								<UsersGroupIcon />
+								<UsersIcon />
 								<span>Members</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>


### PR DESCRIPTION
Part of a stack (bottom → top):
1. **chore/phosphor-icons** ← this PR
2. chore/pie-chart
3. chore/dashboard-tweaks

Swap sidebar & mobile nav icons from tabler to phosphor equivalents:
- Dashboard: `SquaresFourIcon`
- Transactions: `ArrowsLeftRightIcon`
- Recurring Bills: `RepeatIcon`
- Events: `CalendarStarIcon`
- Categories: `ShapesIcon`
- Wallets / Files / Workspace / Members: phosphor equivalents (`WalletIcon`, `FileIcon`, `TentIcon`, `UsersIcon`)

Also updates the category icon in the expense filter dropdown for consistency.