### PR TITLE
chore: tidy dashboard widgets & workspace cards

### DIFF
--- a/apps/app/src/components/charts/category-breakdown.tsx
+++ b/apps/app/src/components/charts/category-breakdown.tsx
@@ -1,13 +1,11 @@
 import { Button } from "@hoalu/ui/button";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@hoalu/ui/card";
 import {
-	Card,
-	CardAction,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@hoalu/ui/card";
-import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@hoalu/ui/chart";
+	type ChartConfig,
+	ChartContainer,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "@hoalu/ui/chart";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@hoalu/ui/empty";
 import { cn } from "@hoalu/ui/utils";
 import { useValue } from "@legendapp/state/react";
@@ -82,6 +80,7 @@ function DonutBreakdown(props: { data: CategoryData[]; totalAmount: number; curr
 					outerRadius="90%"
 					paddingAngle={2}
 					cornerRadius={4}
+					isAnimationActive={false}
 				/>
 			</PieChart>
 		</ChartContainer>
@@ -232,7 +231,6 @@ export function CategoryBreakdown(props: CategoryBreakdownProps) {
 		<Card className="h-full pb-2">
 			<CardHeader>
 				<CardTitle>Categories Breakdown</CardTitle>
-				<CardDescription>Top {TOP_N_CATEGORY} categories</CardDescription>
 				<CardAction>
 					{dataToView.length > TOP_N_CATEGORY && (
 						<div className="flex justify-end">

--- a/apps/app/src/components/expenses/expense-filter-dropdown.tsx
+++ b/apps/app/src/components/expenses/expense-filter-dropdown.tsx
@@ -6,11 +6,12 @@ import {
 	FunnelIcon,
 	FadersHorizontalIcon,
 	ArrowsClockwiseIcon,
+	ShapesIcon,
 	TagIcon,
 	WalletIcon,
 	XIcon,
 } from "@hoalu/icons/phosphor";
-import { CaretRightFilledIcon, TriangleSquareCircleIcon } from "@hoalu/icons/tabler";
+import { CaretRightFilledIcon } from "@hoalu/icons/tabler";
 import { Badge } from "@hoalu/ui/badge";
 import { Button } from "@hoalu/ui/button";
 import { Calendar } from "@hoalu/ui/calendar";
@@ -223,7 +224,7 @@ export function ExpenseFilterDropdown() {
 								onClick={() => setCurrentView("amount")}
 							/>
 							<FilterMenuItem
-								icon={<TriangleSquareCircleIcon />}
+								icon={<ShapesIcon />}
 								label="Category"
 								active={hasActiveFilter("category")}
 								selected={currentView === "category"}

--- a/apps/app/src/components/layouts/mobile-layout.tsx
+++ b/apps/app/src/components/layouts/mobile-layout.tsx
@@ -1,10 +1,12 @@
 import {
+	ArrowsLeftRightIcon,
 	CheckIcon,
 	CaretUpDownIcon,
 	PaletteIcon,
 	MagnifyingGlassIcon,
+	SquaresFourIcon,
 } from "@hoalu/icons/phosphor";
-import { ArrowsExchangeIcon, LayoutDashboardIcon, SettingsIcon } from "@hoalu/icons/tabler";
+import { SettingsIcon } from "@hoalu/icons/tabler";
 import { Avatar, AvatarFallback } from "@hoalu/ui/avatar";
 import { Button } from "@hoalu/ui/button";
 import {
@@ -168,7 +170,7 @@ function MobileBottomNav() {
 						className: activeNavItemClass,
 					}}
 				>
-					<LayoutDashboardIcon className="size-6" aria-hidden="true" />
+					<SquaresFourIcon className="size-6" aria-hidden="true" />
 					<span className="truncate text-xs leading-none">Dashboard</span>
 				</ButtonLink>
 				<ButtonLink
@@ -182,7 +184,7 @@ function MobileBottomNav() {
 						className: activeNavItemClass,
 					}}
 				>
-					<ArrowsExchangeIcon className="size-6" aria-hidden="true" />
+					<ArrowsLeftRightIcon className="size-6" aria-hidden="true" />
 					<span className="truncate text-xs leading-none">Transactions</span>
 				</ButtonLink>
 				<ButtonLink

--- a/apps/app/src/components/layouts/nav-workspace.tsx
+++ b/apps/app/src/components/layouts/nav-workspace.tsx
@@ -1,15 +1,15 @@
-import { MagnifyingGlassIcon } from "@hoalu/icons/phosphor";
 import {
-	CalendarDollarIcon,
+	ArrowsLeftRightIcon,
+	CalendarStarIcon,
 	FileIcon,
-	LayoutDashboardIcon,
+	MagnifyingGlassIcon,
+	RepeatIcon,
+	ShapesIcon,
+	SquaresFourIcon,
 	TentIcon,
-	TriangleSquareCircleIcon,
-	UsersGroupIcon,
+	UsersIcon,
 	WalletIcon,
-	CalendarClockIcon,
-	ArrowsExchangeIcon,
-} from "@hoalu/icons/tabler";
+} from "@hoalu/icons/phosphor";
 import { Button } from "@hoalu/ui/button";
 import {
 	SidebarGroup,
@@ -52,7 +52,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug" params={{ slug }} activeOptions={{ exact: true }} />}
 								tooltip="Dashboard"
 							>
-								<LayoutDashboardIcon />
+								<SquaresFourIcon />
 								<span>Dashboard</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -75,7 +75,7 @@ export function NavWorkspace() {
 								}
 								tooltip="Transactions"
 							>
-								<ArrowsExchangeIcon />
+								<ArrowsLeftRightIcon />
 								<span>Transactions</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -85,7 +85,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug/recurring-bills" params={{ slug }} />}
 								tooltip="Recurring Bills"
 							>
-								<CalendarDollarIcon />
+								<RepeatIcon />
 								<span>Recurring Bills</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -95,7 +95,7 @@ export function NavWorkspace() {
 								render={<Link to="/$slug/events" params={{ slug }} />}
 								tooltip="Events"
 							>
-								<CalendarClockIcon />
+								<CalendarStarIcon />
 								<span>Events</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -109,7 +109,7 @@ export function NavWorkspace() {
 					<SidebarMenu>
 						<SidebarMenuItem>
 							<SidebarMenuButton render={<Link to="/$slug/categories" params={{ slug }} />}>
-								<TriangleSquareCircleIcon />
+								<ShapesIcon />
 								<span>Categories</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>
@@ -143,7 +143,7 @@ export function NavWorkspace() {
 						</SidebarMenuItem>
 						<SidebarMenuItem>
 							<SidebarMenuButton render={<Link to="/$slug/settings/members" params={{ slug }} />}>
-								<UsersGroupIcon />
+								<UsersIcon />
 								<span>Members</span>
 							</SidebarMenuButton>
 						</SidebarMenuItem>

--- a/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
+++ b/apps/app/src/components/upcoming-bills/upcoming-bills-list.tsx
@@ -251,16 +251,3 @@ function UpcomingBillRow({ bill }: UpcomingBillRowProps) {
 		</div>
 	);
 }
-
-const colorMap: Record<string, string> = {
-	red: "bg-red-400",
-	green: "bg-emerald-400",
-	teal: "bg-teal-400",
-	blue: "bg-blue-400",
-	yellow: "bg-amber-300",
-	orange: "bg-orange-400",
-	purple: "bg-violet-400",
-	pink: "bg-pink-400",
-	gray: "bg-slate-300",
-	stone: "bg-stone-300",
-};

--- a/apps/app/src/components/upcoming-bills/upcoming-bills-widget.tsx
+++ b/apps/app/src/components/upcoming-bills/upcoming-bills-widget.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@hoalu/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@hoalu/ui/card";
 import { useQuery } from "@tanstack/react-query";
 
@@ -10,15 +9,13 @@ export function UpcomingBillsWidget() {
 	const workspace = useWorkspace();
 	const { data } = useQuery(unifiedBillsQueryOptions(workspace.slug));
 
-	const totalCount =
-		(data?.overdue.length ?? 0) + (data?.today.length ?? 0) + (data?.upcoming.length ?? 0);
+	// const totalCount =
+	// 	(data?.overdue.length ?? 0) + (data?.today.length ?? 0) + (data?.upcoming.length ?? 0);
 
 	return (
 		<Card>
 			<CardHeader>
-				<CardTitle className="flex items-center gap-2">
-					Upcoming Bills <Badge variant="info">{totalCount}</Badge>
-				</CardTitle>
+				<CardTitle className="flex items-center gap-2">Upcoming Bills</CardTitle>
 				<CardDescription>Next 30 days, yearly and overdue bills</CardDescription>
 			</CardHeader>
 			<CardContent className="max-h-90 px-0">

--- a/apps/app/src/routes/_dashboard/index.tsx
+++ b/apps/app/src/routes/_dashboard/index.tsx
@@ -70,14 +70,6 @@ function RouteComponent() {
 							<SectionDescription>Select a workspace</SectionDescription>
 						</SectionHeader>
 						<SectionContent columns={3} className="grid-cols-1">
-							{workspaces.map((ws) => {
-								const summary = summaryMap.get(ws.id);
-								return (
-									<Link key={ws.id} to="/$slug" params={{ slug: ws.slug }} className="group h-full">
-										<WorkspaceCard {...ws} summary={summary} />
-									</Link>
-								);
-							})}
 							<Card
 								className="hover:border-foreground/40 h-full min-h-40 cursor-pointer justify-center rounded-md border-dashed bg-transparent"
 								onClick={() => setDialog({ state: true })}
@@ -87,6 +79,14 @@ function RouteComponent() {
 									<span className="text-muted-foreground text-sm">New workspace</span>
 								</div>
 							</Card>
+							{workspaces.map((ws) => {
+								const summary = summaryMap.get(ws.id);
+								return (
+									<Link key={ws.id} to="/$slug" params={{ slug: ws.slug }} className="group h-full">
+										<WorkspaceCard {...ws} summary={summary} />
+									</Link>
+								);
+							})}
 						</SectionContent>
 					</Section>
 				)}


### PR DESCRIPTION
Part of a stack (bottom → top):
1. chore/phosphor-icons
2. chore/pie-chart
3. **chore/dashboard-tweaks** ← this PR

- Remove count badge from Upcoming Bills widget title
- Remove unused `colorMap` from upcoming-bills list
- Move "New workspace" card before the workspace list on the dashboard